### PR TITLE
Ability to save timelines as presets

### DIFF
--- a/KeyframelessAI/Sources/KeyframelessAI/Knowledge/AIKnowledgeBridge.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Knowledge/AIKnowledgeBridge.swift
@@ -21,6 +21,7 @@ public final class AIKnowledgeBridge: NSObject {
 		"animated-properties", "multi-component-properties", "value-editing",
 		"motion-blur", "snap-guides", "constants-panel", "inspector-controls",
 		"mini-viewer", "clip-space-and-wrapping", "guides", "shortcuts",
+		"presets",
 	]
 
 	@MainActor

--- a/KeyframelessAI/Sources/KeyframelessAI/State/AIDraftBridge.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/State/AIDraftBridge.swift
@@ -29,9 +29,12 @@ public final class AIDraftBridge: NSObject {
 		AIDraftState.shared.routingStatus = status
 	}
 
+	/// Set the pending answer. A non-nil answer also lights the green "done"
+	/// sparkle (until the user next interacts), like an applied mutation does.
 	@MainActor
 	@objc public static func setAnswer(_ answer: String?) {
 		AIDraftState.shared.pendingAnswer = answer
+		AIDraftState.shared.didAnswerQuestion = (answer != nil)
 	}
 
 	@MainActor

--- a/KeyframelessAI/Sources/KeyframelessAI/State/AIDraftState.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/State/AIDraftState.swift
@@ -27,6 +27,11 @@ public final class AIDraftState: ObservableObject {
 	/// still has a confirmation waiting when the user looks back. Answers and
 	/// errors do not set this - only an applied mutation does.
 	@Published public var didCompleteMutation: Bool = false
+	/// True once a question has been answered, until the user next interacts.
+	/// Drives the same green "done" sparkle as `didCompleteMutation` so a
+	/// fire-and-look-away question also leaves a badge waiting (plugins + the
+	/// Steno workflow extension).
+	@Published public var didAnswerQuestion: Bool = false
 
 	private init() {}
 
@@ -36,5 +41,6 @@ public final class AIDraftState: ObservableObject {
 		routingError = nil
 		routingStatus = nil
 		didCompleteMutation = false
+		didAnswerQuestion = false
 	}
 }

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/AIActionTab.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/AIActionTab.swift
@@ -48,6 +48,9 @@ struct AIActionTab: View {
 			if !newValue.isEmpty && draft.didCompleteMutation {
 				draft.didCompleteMutation = false
 			}
+			if !newValue.isEmpty && draft.didAnswerQuestion {
+				draft.didAnswerQuestion = false
+			}
 		}
 	}
 
@@ -219,6 +222,7 @@ struct AIActionTab: View {
 		guard canRun, keyState.activeIsConfigured else { return }
 		draft.routingError = nil
 		draft.didCompleteMutation = false
+		draft.didAnswerQuestion = false
 
 		if isPluginMode {
 			// Plugin host owns routing: it has live timeline state and a custom
@@ -249,6 +253,7 @@ struct AIActionTab: View {
 				case .answer(let reply):
 					draft.isRouting = false
 					draft.pendingAnswer = reply
+					draft.didAnswerQuestion = true
 				}
 			} catch {
 				draft.isRouting = false

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/AIButton.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/AIButton.swift
@@ -37,7 +37,7 @@ public struct AIButton: View {
 	private var iconState: SparkleIcon.State {
 		if !keyState.hasAnyKey { return .unconfigured }
 		if draft.isRouting { return .running }
-		if draft.didCompleteMutation { return .done }
+		if draft.didCompleteMutation || draft.didAnswerQuestion { return .done }
 		return .idle
 	}
 
@@ -55,6 +55,7 @@ public struct AIButton: View {
 			// Opening (or otherwise tapping) the icon counts as the user
 			// coming back to review, so clear the lingering "done" state.
 			draft.didCompleteMutation = false
+			draft.didAnswerQuestion = false
 			showPopover.toggle()
 		} label: {
 			SparkleIcon(state: iconState)

--- a/KeyframelessKit/KeyframelessKit/Math/Timing/KKPresetTimelineOps.h
+++ b/KeyframelessKit/KeyframelessKit/Math/Timing/KKPresetTimelineOps.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+@class KKTimeline;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Pure timeline transforms backing the presets feature (no view state). All
+/// take the live clip duration explicitly so they stay testable and reusable.
+
+/// Remap the preset's full time extent onto `[start, end]` (normalized by its
+/// own min/max, so it fits regardless of authoring duration), then pin locked
+/// transition gaps to their seconds for `clipDurSec` while flexible holds
+/// absorb the remainder. `clipDurSec <= 0` (or nothing locked) skips the
+/// rebalance.
+FOUNDATION_EXPORT KKTimeline *KKPresetTimelineRemapped(KKTimeline *preset,
+                                                       double start, double end,
+                                                       double clipDurSec);
+
+/// Merge the preset into `current` so its (remapped + rebalanced) animation
+/// occupies `[p, end]`: each lane keeps its keyposes before `p`, then appends
+/// the preset's. Only the preset's ENABLED lanes merge (disabled/unused lanes
+/// leave the current lane untouched); preset-only lanes are added; redundant
+/// flat-hold keyposes at the seam are collapsed. `current` nil = remap only.
+FOUNDATION_EXPORT KKTimeline *
+KKPresetTimelineMergedAtFraction(KKTimeline *preset,
+                                 KKTimeline *_Nullable current, double p,
+                                 double end, double clipDurSec);
+
+/// Capture each MOVING gap's real duration (seconds) as `lockedSeconds` and
+/// leave flat/hold gaps flexible (0) - so a saved preset reproduces its
+/// transition feel at a fixed wall-clock length while holds stretch.
+/// `clipDurSec <= 0` returns the timeline unchanged.
+FOUNDATION_EXPORT KKTimeline *KKPresetTimelineAutoLocked(KKTimeline *timeline,
+                                                         double clipDurSec);
+
+NS_ASSUME_NONNULL_END

--- a/KeyframelessKit/KeyframelessKit/Math/Timing/KKPresetTimelineOps.m
+++ b/KeyframelessKit/KeyframelessKit/Math/Timing/KKPresetTimelineOps.m
@@ -1,0 +1,198 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+#import "KKPresetTimelineOps.h"
+
+#import "KKTimingStage.h"
+
+static BOOL _kkAnyLockedSeconds(KKTimeline *t) {
+  for (KKLane *l in t.lanes)
+    for (KKKeyPose *k in l.keyposes)
+      if (k.outgoing.lockedSeconds > 0.0)
+        return YES;
+  return NO;
+}
+
+static BOOL _kkValuesEqual(NSArray<NSNumber *> *a, NSArray<NSNumber *> *b) {
+  if (a.count != b.count)
+    return NO;
+  for (NSUInteger i = 0; i < a.count; i++)
+    if (fabs(a[i].doubleValue - b[i].doubleValue) > 1e-6)
+      return NO;
+  return YES;
+}
+
+// Drop interior keyposes that sit inside a flat hold (equal value to both
+// neighbours) with no modulation or spatial handles - merging an in-preset then
+// an out-preset leaves a redundant hold point at the seam. The curve is
+// irrelevant across equal values, so removal is visually identical; the kept
+// previous keypose's interval simply spans the wider flat region.
+static KKLane *_kkLaneCollapsingFlatHolds(KKLane *lane) {
+  NSArray<KKKeyPose *> *kps = lane.keyposes;
+  if (kps.count < 3)
+    return lane;
+  NSMutableArray<KKKeyPose *> *out = [NSMutableArray arrayWithObject:kps[0]];
+  for (NSUInteger i = 1; i + 1 < kps.count; i++) {
+    KKKeyPose *prev = out.lastObject;
+    KKKeyPose *cur = kps[i];
+    KKKeyPose *next = kps[i + 1];
+    BOOL flat = _kkValuesEqual(prev.values, cur.values) &&
+                _kkValuesEqual(cur.values, next.values);
+    BOOL noMod =
+        (!prev.outgoing ||
+         prev.outgoing.modulation == KKIntervalModulationNone) &&
+        (!cur.outgoing || cur.outgoing.modulation == KKIntervalModulationNone);
+    BOOL noSpatial =
+        (cur.inHandle == nil && cur.outHandle == nil && !cur.spatialSmooth);
+    if (flat && noMod && noSpatial)
+      continue; // drop cur; prev's interval now spans the flat region
+    [out addObject:cur];
+  }
+  [out addObject:kps.lastObject];
+  if (out.count == kps.count)
+    return lane;
+  KKLane *nl = [lane copy];
+  nl.keyposes = out;
+  return nl;
+}
+
+static void _kkPresetTimeBounds(KKTimeline *t, double *outMin, double *outMax) {
+  double mn = INFINITY, mx = -INFINITY;
+  for (KKLane *l in t.lanes)
+    for (KKKeyPose *k in l.keyposes) {
+      if (k.time < mn)
+        mn = k.time;
+      if (k.time > mx)
+        mx = k.time;
+    }
+  if (mn == INFINITY) {
+    mn = 0.0;
+    mx = 0.0;
+  }
+  *outMin = mn;
+  *outMax = mx;
+}
+
+KKTimeline *KKPresetTimelineRemapped(KKTimeline *preset, double start,
+                                     double end, double clipDurSec) {
+  double tmin = 0.0, tmax = 0.0;
+  _kkPresetTimeBounds(preset, &tmin, &tmax);
+  double srcSpan = tmax - tmin;
+  double dstSpan = end - start;
+  KKTimeline *out = [preset copy];
+  NSMutableArray<KKLane *> *lanes =
+      [NSMutableArray arrayWithCapacity:preset.lanes.count];
+  for (KKLane *lane in preset.lanes) {
+    KKLane *nl = [lane copy];
+    NSMutableArray<KKKeyPose *> *kps =
+        [NSMutableArray arrayWithCapacity:lane.keyposes.count];
+    for (KKKeyPose *kp in lane.keyposes) {
+      double nt = (srcSpan > 1e-9)
+                      ? start + (kp.time - tmin) / srcSpan * dstSpan
+                      : start;
+      [kps addObject:[kp keyposeBySettingTime:nt]];
+    }
+    nl.keyposes = kps;
+    [lanes addObject:nl];
+  }
+  out.lanes = lanes;
+  // Pin fixed transition durations for this clip: the remap above set the
+  // endpoints + proportional layout; rebalance keeps locked gaps at their
+  // seconds and lets flexible holds absorb the rest. Only when the clip
+  // duration is known and something is actually locked (else a no-op).
+  // `oldDuration` only gates KKTimelineRebalanced's early-return, so passing a
+  // value != clipDur forces it to run.
+  if (clipDurSec > 0.0 && _kkAnyLockedSeconds(out))
+    out = KKTimelineRebalanced(out, clipDurSec + 1.0, clipDurSec);
+  return out;
+}
+
+KKTimeline *KKPresetTimelineMergedAtFraction(KKTimeline *preset,
+                                             KKTimeline *current, double p,
+                                             double end, double clipDurSec) {
+  if (!current)
+    return KKPresetTimelineRemapped(preset, p, end, clipDurSec);
+
+  KKTimeline *remapped = KKPresetTimelineRemapped(preset, p, end, clipDurSec);
+  NSMutableDictionary<NSString *, KKLane *> *presetByLabel =
+      [NSMutableDictionary dictionary];
+  for (KKLane *l in remapped.lanes)
+    if (l.label)
+      presetByLabel[l.label] = l;
+
+  KKTimeline *out = [current copy];
+  NSMutableArray<KKLane *> *merged =
+      [NSMutableArray arrayWithCapacity:current.lanes.count];
+  NSMutableSet<NSString *> *consumed = [NSMutableSet set];
+  for (KKLane *cur in current.lanes) {
+    KKLane *pl = cur.label ? presetByLabel[cur.label] : nil;
+    // Only the preset's ANIMATED lanes merge in; its disabled (unused) lanes
+    // leave the current lane untouched - otherwise an insert turns every param
+    // animatable.
+    if (!pl || !pl.enabled) {
+      [merged addObject:cur];
+      if (pl)
+        [consumed addObject:cur.label];
+      continue;
+    }
+    [consumed addObject:cur.label];
+    NSMutableArray<KKKeyPose *> *kps = [NSMutableArray array];
+    for (KKKeyPose *kp in cur.keyposes)
+      if (kp.time < p - 1e-6)
+        [kps addObject:kp];
+    // The last kept keypose must carry an interval to bridge into the preset
+    // region (the original lane's final keypose has none).
+    if (kps.count && !kps.lastObject.outgoing) {
+      KKKeyPose *lc = [kps.lastObject copy];
+      lc.outgoing = [[KKInterval alloc] init];
+      kps[kps.count - 1] = lc;
+    }
+    [kps addObjectsFromArray:pl.keyposes];
+    KKLane *nl = [cur copy];
+    nl.keyposes = kps;
+    nl.enabled = YES;
+    nl.holdShape = KKLaneHoldShapeAuto;
+    [merged addObject:_kkLaneCollapsingFlatHolds(nl)];
+  }
+  for (KKLane *pl in remapped.lanes)
+    if (pl.enabled && (!pl.label || ![consumed containsObject:pl.label])) {
+      KKLane *nl = [pl copy];
+      nl.enabled = YES;
+      [merged addObject:nl];
+    }
+  out.lanes = merged;
+  return out;
+}
+
+KKTimeline *KKPresetTimelineAutoLocked(KKTimeline *timeline,
+                                       double clipDurSec) {
+  if (!timeline || clipDurSec <= 0.0)
+    return timeline;
+  KKTimeline *out = [timeline copy];
+  NSMutableArray<KKLane *> *lanes =
+      [NSMutableArray arrayWithCapacity:timeline.lanes.count];
+  for (KKLane *lane in timeline.lanes) {
+    KKLane *nl = [lane copy];
+    NSArray<KKKeyPose *> *src = lane.keyposes;
+    NSMutableArray<KKKeyPose *> *kps =
+        [NSMutableArray arrayWithCapacity:src.count];
+    for (NSUInteger i = 0; i < src.count; i++) {
+      KKKeyPose *kp = [src[i] copy];
+      if (i + 1 < src.count && kp.outgoing) {
+        KKInterval *iv = [kp.outgoing copy];
+        BOOL moving =
+            !iv.holdsFlat && !_kkValuesEqual(kp.values, src[i + 1].values);
+        iv.lockedSeconds =
+            moving ? (src[i + 1].time - kp.time) * clipDurSec : 0.0;
+        kp.outgoing = iv;
+      }
+      [kps addObject:kp];
+    }
+    nl.keyposes = kps;
+    [lanes addObject:nl];
+  }
+  out.lanes = lanes;
+  return out;
+}

--- a/KeyframelessKit/KeyframelessKit/Plugin/CustomViews/KKPlugin+Help.m
+++ b/KeyframelessKit/KeyframelessKit/Plugin/CustomViews/KKPlugin+Help.m
@@ -255,6 +255,9 @@
                                topic:@"easing"
                               symbol:@"point.topleft.down.curvedto."
                                      @"point.bottomright.up"],
+    [self _knowledgeSectionWithTitle:KKLoc(@"Presets", @"Help section title.")
+                               topic:@"presets"
+                              symbol:@"bookmark"],
     [self _builtInTimingShortcutsSection],
   ];
 }

--- a/KeyframelessKit/KeyframelessKit/Plugin/CustomViews/KKPlugin+InspectorCallbacks.m
+++ b/KeyframelessKit/KeyframelessKit/Plugin/CustomViews/KKPlugin+InspectorCallbacks.m
@@ -84,6 +84,10 @@
   __weak typeof(self) weak = self;
   __weak KKTimelineInspectorView *weakView = view;
 
+  // Namespace the Presets row to this plugin so its saved/built-in presets
+  // never bleed across plugins (their lane sets differ).
+  view.presetPluginKey = [self presetPluginKey];
+
   view.onLoopToggled = ^(BOOL enabled) {
     __strong typeof(weak) strong = weak;
     if (!strong)

--- a/KeyframelessKit/KeyframelessKit/Plugin/KKPlugin.h
+++ b/KeyframelessKit/KeyframelessKit/Plugin/KKPlugin.h
@@ -62,6 +62,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithAPIManager:(id<PROAPIAccessing>)apiManager;
 
+/// Namespace under which this plugin's animation presets are stored and listed
+/// (see KKPresets / the inspector Presets row). Defaults to the plugin's bundle
+/// identifier - stable and unique per plugin. Override only to share a preset
+/// namespace between plugins.
+- (NSString *)presetPluginKey;
+
 /// Convenience wrapper around KKMetalDeviceCache buildAndRegisterPipelineState.
 /// Call from renderDestinationImage: to get or build the pipeline state for
 /// this plugin.

--- a/KeyframelessKit/KeyframelessKit/Plugin/KKPlugin.m
+++ b/KeyframelessKit/KeyframelessKit/Plugin/KKPlugin.m
@@ -60,6 +60,11 @@
   return self;
 }
 
+- (NSString *)presetPluginKey {
+  return [NSBundle bundleForClass:[self class]].bundleIdentifier
+             ?: NSStringFromClass([self class]);
+}
+
 - (void)setTimingGroupExtraParamIDs:(NSArray<NSNumber *> *)ids {
   objc_setAssociatedObject([self class], kKKTimingExtraIDs, [ids copy],
                            OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/KeyframelessKit/KeyframelessKit/Plugin/Support/KKPresets.h
+++ b/KeyframelessKit/KeyframelessKit/Plugin/Support/KKPresets.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// One saved animation preset: a named copy of the timeline JSON blob
+/// (`kKKParamTimelineData`), scoped to a plugin. `builtin` presets ship in the
+/// framework bundle, are read-only (no delete / rename / overwrite) and render
+/// with a "Default" badge; their `name` is a localization key looked up for
+/// display.
+@interface KKPreset : NSObject
+@property(nonatomic, copy) NSString *identifier;
+@property(nonatomic, copy) NSString *name;
+@property(nonatomic, copy) NSString *pluginKey;
+@property(nonatomic, copy) NSString *timelineJSON;
+@property(nonatomic, assign) BOOL builtin;
+/// Display name: built-ins resolve `name` through the localization table;
+/// user presets return `name` verbatim.
+@property(nonatomic, readonly) NSString *displayName;
+@end
+
+/// Per-plugin preset library. User presets persist as JSON in
+/// `~/Library/Application Support/Keyframeless/presets.json`; built-ins load
+/// from per-plugin bundle resources at first access. Mirrors the gradient
+/// favorites store (`KKGradientFavorites`).
+@interface KKPresets : NSObject
++ (instancetype)shared;
+
+/// Built-ins first (each tagged `builtin`), then user presets; each group
+/// sorted case-insensitively by display name.
+- (NSArray<KKPreset *> *)presetsForPluginKey:(NSString *)pluginKey;
+
+- (KKPreset *)addPresetWithName:(NSString *)name
+                      pluginKey:(NSString *)pluginKey
+                   timelineJSON:(NSString *)timelineJSON;
+/// No-ops on a built-in or unknown identifier.
+- (void)removePresetWithIdentifier:(NSString *)identifier;
+- (void)renamePresetWithIdentifier:(NSString *)identifier
+                            toName:(NSString *)name;
+- (void)updatePresetWithIdentifier:(NSString *)identifier
+                      timelineJSON:(NSString *)timelineJSON;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/KeyframelessKit/KeyframelessKit/Plugin/Support/KKPresets.m
+++ b/KeyframelessKit/KeyframelessKit/Plugin/Support/KKPresets.m
@@ -1,0 +1,246 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+#import "KKPresets.h"
+
+#import "KKLocalized.h"
+
+static NSString *const kFileName = @"presets.json";
+// Bundled built-ins for every plugin, keyed by plugin key (the plugin's bundle
+// identifier). One flat file so the lookup is robust to any bundle id - Xcode
+// flattens resources to the framework bundle root.
+static NSString *const kBuiltinResource = @"builtin_presets";
+
+static NSURL *_presetsFileURL(void) {
+  NSArray<NSString *> *paths = NSSearchPathForDirectoriesInDomains(
+      NSApplicationSupportDirectory, NSUserDomainMask, YES);
+  if (paths.count == 0)
+    return nil;
+  NSString *dir =
+      [paths.firstObject stringByAppendingPathComponent:@"Keyframeless"];
+  [[NSFileManager defaultManager] createDirectoryAtPath:dir
+                            withIntermediateDirectories:YES
+                                             attributes:nil
+                                                  error:nil];
+  return [NSURL fileURLWithPath:[dir stringByAppendingPathComponent:kFileName]];
+}
+
+@implementation KKPreset
+
+- (NSString *)displayName {
+  if (!_builtin)
+    return _name;
+  // Built-in names are stable English keys in the KKLocalizable table.
+  return NSLocalizedStringFromTableInBundle(_name, @"KKLocalizable",
+                                            KKLocalizationBundle(), nil)
+             ?: _name;
+}
+
+@end
+
+@implementation KKPresets {
+  NSMutableArray<KKPreset *> *_userItems;
+  // Built-ins are loaded once per plugin key and cached.
+  NSMutableDictionary<NSString *, NSArray<KKPreset *> *> *_builtinsByPlugin;
+  // The parsed builtin_presets.json root (pluginKey -> array of entries),
+  // loaded lazily once.
+  NSDictionary *_builtinRoot;
+  BOOL _builtinRootLoaded;
+}
+
++ (instancetype)shared {
+  static KKPresets *instance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    instance = [[KKPresets alloc] init];
+  });
+  return instance;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _userItems = [NSMutableArray new];
+    _builtinsByPlugin = [NSMutableDictionary new];
+    [self _load];
+  }
+  return self;
+}
+
+- (NSArray<KKPreset *> *)presetsForPluginKey:(NSString *)pluginKey {
+  NSComparator byName = ^(KKPreset *a, KKPreset *b) {
+    return [a.displayName localizedCaseInsensitiveCompare:b.displayName];
+  };
+
+  NSArray<KKPreset *> *builtins = [[self _builtinsForPluginKey:pluginKey]
+      sortedArrayUsingComparator:byName];
+
+  NSMutableArray<KKPreset *> *userMatches = [NSMutableArray new];
+  for (KKPreset *p in _userItems)
+    if ([p.pluginKey isEqualToString:pluginKey])
+      [userMatches addObject:p];
+  [userMatches sortUsingComparator:byName];
+
+  NSMutableArray<KKPreset *> *all = [NSMutableArray new];
+  [all addObjectsFromArray:builtins];
+  [all addObjectsFromArray:userMatches];
+  return all;
+}
+
+- (KKPreset *)addPresetWithName:(NSString *)name
+                      pluginKey:(NSString *)pluginKey
+                   timelineJSON:(NSString *)timelineJSON {
+  KKPreset *p = [[KKPreset alloc] init];
+  p.identifier = [[NSUUID UUID] UUIDString];
+  p.name = name;
+  p.pluginKey = pluginKey;
+  p.timelineJSON = timelineJSON;
+  p.builtin = NO;
+  [_userItems addObject:p];
+  [self _save];
+  return p;
+}
+
+- (void)removePresetWithIdentifier:(NSString *)identifier {
+  NSUInteger idx = [self _userIndexForIdentifier:identifier];
+  if (idx != NSNotFound) {
+    [_userItems removeObjectAtIndex:idx];
+    [self _save];
+  }
+}
+
+- (void)renamePresetWithIdentifier:(NSString *)identifier
+                            toName:(NSString *)name {
+  NSUInteger idx = [self _userIndexForIdentifier:identifier];
+  if (idx != NSNotFound) {
+    _userItems[idx].name = name;
+    [self _save];
+  }
+}
+
+- (void)updatePresetWithIdentifier:(NSString *)identifier
+                      timelineJSON:(NSString *)timelineJSON {
+  NSUInteger idx = [self _userIndexForIdentifier:identifier];
+  if (idx != NSNotFound) {
+    _userItems[idx].timelineJSON = timelineJSON;
+    [self _save];
+  }
+}
+
+- (NSUInteger)_userIndexForIdentifier:(NSString *)identifier {
+  return [_userItems
+      indexOfObjectPassingTest:^(KKPreset *p, NSUInteger i, BOOL *stop) {
+        return [p.identifier isEqualToString:identifier];
+      }];
+}
+
+- (NSArray<KKPreset *> *)_builtinsForPluginKey:(NSString *)pluginKey {
+  NSArray<KKPreset *> *cached = _builtinsByPlugin[pluginKey];
+  if (cached)
+    return cached;
+
+  if (!_builtinRootLoaded) {
+    _builtinRootLoaded = YES;
+    NSURL *url = [KKLocalizationBundle() URLForResource:kBuiltinResource
+                                          withExtension:@"json"];
+    NSData *data = url ? [NSData dataWithContentsOfURL:url] : nil;
+    id root = data ? [NSJSONSerialization JSONObjectWithData:data
+                                                     options:0
+                                                       error:nil]
+                   : nil;
+    if ([root isKindOfClass:[NSDictionary class]])
+      _builtinRoot = root;
+  }
+
+  NSMutableArray<KKPreset *> *items = [NSMutableArray new];
+  NSArray *arr = _builtinRoot[pluginKey];
+  if ([arr isKindOfClass:[NSArray class]]) {
+    for (NSDictionary *d in arr) {
+      if (![d isKindOfClass:[NSDictionary class]])
+        continue;
+      NSString *identifier = d[@"id"];
+      NSString *name = d[@"name"];
+      // `timeline` may be an embedded JSON object (authorable) or an already
+      // serialized string; normalize to a string.
+      NSString *timeline = nil;
+      id timelineVal = d[@"timeline"];
+      if ([timelineVal isKindOfClass:[NSString class]]) {
+        timeline = timelineVal;
+      } else if ([timelineVal isKindOfClass:[NSDictionary class]]) {
+        NSData *td = [NSJSONSerialization dataWithJSONObject:timelineVal
+                                                     options:0
+                                                       error:nil];
+        timeline = td ? [[NSString alloc] initWithData:td
+                                              encoding:NSUTF8StringEncoding]
+                      : nil;
+      }
+      if (!identifier.length || !name.length || !timeline.length)
+        continue;
+      KKPreset *p = [[KKPreset alloc] init];
+      p.identifier = identifier;
+      p.name = name;
+      p.pluginKey = pluginKey;
+      p.timelineJSON = timeline;
+      p.builtin = YES;
+      [items addObject:p];
+    }
+  }
+  _builtinsByPlugin[pluginKey] = items;
+  return items;
+}
+
+- (void)_load {
+  NSURL *url = _presetsFileURL();
+  if (!url)
+    return;
+  NSData *data = [NSData dataWithContentsOfURL:url];
+  if (!data)
+    return;
+  NSArray *arr = [NSJSONSerialization JSONObjectWithData:data
+                                                 options:0
+                                                   error:nil];
+  if (![arr isKindOfClass:[NSArray class]])
+    return;
+  for (NSDictionary *d in arr) {
+    if (![d isKindOfClass:[NSDictionary class]])
+      continue;
+    NSString *identifier = d[@"id"];
+    NSString *name = d[@"name"];
+    NSString *pluginKey = d[@"pluginKey"];
+    NSString *timeline = d[@"timeline"];
+    if (!identifier.length || !name.length || !pluginKey.length ||
+        !timeline.length)
+      continue;
+    KKPreset *p = [[KKPreset alloc] init];
+    p.identifier = identifier;
+    p.name = name;
+    p.pluginKey = pluginKey;
+    p.timelineJSON = timeline;
+    p.builtin = NO;
+    [_userItems addObject:p];
+  }
+}
+
+- (void)_save {
+  NSURL *url = _presetsFileURL();
+  if (!url)
+    return;
+  NSMutableArray *arr = [NSMutableArray new];
+  for (KKPreset *p in _userItems) {
+    [arr addObject:@{
+      @"id" : p.identifier,
+      @"name" : p.name,
+      @"pluginKey" : p.pluginKey,
+      @"timeline" : p.timelineJSON
+    }];
+  }
+  NSData *data = [NSJSONSerialization dataWithJSONObject:arr
+                                                 options:0
+                                                   error:nil];
+  if (data)
+    [data writeToURL:url atomically:YES];
+}
+
+@end

--- a/KeyframelessKit/KeyframelessKit/Resources/KKLocalizable.xcstrings
+++ b/KeyframelessKit/KeyframelessKit/Resources/KKLocalizable.xcstrings
@@ -9030,6 +9030,552 @@
           }
         }
       }
+    },
+    "Save an animation you like and re-apply it to any clip from the <accent>Presets</accent> row:": {
+      "comment": "Help text.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sichern Sie eine Animation, die Ihnen gefällt, und wenden Sie sie über die Zeile <accent>Presets</accent> auf jeden Clip an:"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guarda una animación que te guste y vuelve a aplicarla a cualquier clip desde la fila <accent>Preajustes</accent>:"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrez une animation qui vous plaît et réappliquez-la à n'importe quel plan depuis la ligne <accent>Préréglages</accent> :"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "気に入ったアニメーションを保存し、<accent>プリセット</accent>の行から任意のクリップに再適用できます:"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마음에 드는 애니메이션을 저장하고 <accent>프리셋</accent> 행에서 모든 클립에 다시 적용하세요:"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存你喜欢的动画，并从<accent>预设</accent>行将其重新应用到任何片段："
+          }
+        }
+      }
+    },
+    "<accent>Default presets</accent> - built-in starters like Pop In and Pop Out, marked with a Default badge. They are read-only.": {
+      "comment": "Help text.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Standard-Presets</accent> - integrierte Vorlagen wie Pop In und Pop Out, mit einem Standard-Badge gekennzeichnet. Sie sind schreibgeschützt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Preajustes predeterminados</accent> - puntos de partida integrados como Aparición pop y Desaparición pop, marcados con la insignia Predeterminado. Son de solo lectura."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Préréglages par défaut</accent> - des points de départ intégrés comme Apparition pop et Disparition pop, marqués d'un badge Par défaut. Ils sont en lecture seule."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>デフォルトプリセット</accent> - ポップインやポップアウトなどの組み込みのひな型で、デフォルトのバッジが付いています。読み取り専用です。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>기본 프리셋</accent> - 팝 인, 팝 아웃 같은 기본 제공 시작점으로, 기본 배지가 표시됩니다. 읽기 전용입니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>默认预设</accent> - 内置的起始动画，例如弹入和弹出，带有“默认”徽章。它们为只读。"
+          }
+        }
+      }
+    },
+    "<accent>Apply</accent> - click a preset to replace the current animation with it.": {
+      "comment": "Help text.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Anwenden</accent> - klicken Sie auf ein Preset, um die aktuelle Animation damit zu ersetzen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Aplicar</accent> - haz clic en un preajuste para reemplazar la animación actual."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Appliquer</accent> - cliquez sur un préréglage pour remplacer l'animation actuelle."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>適用</accent> - プリセットをクリックすると、現在のアニメーションが置き換わります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>적용</accent> - 프리셋을 클릭하면 현재 애니메이션이 대체됩니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>应用</accent> - 点击预设即可替换当前动画。"
+          }
+        }
+      }
+    },
+    "<accent>Apply at playhead</accent> - the insert button drops the preset's move in at the playhead and keeps your existing keyposes, so you can stack a Pop In early and a Pop Out later on the same clip.": {
+      "comment": "Help text.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>An Abspielposition anwenden</accent> - die Einfügen-Taste setzt die Bewegung des Presets an der Abspielposition ein und behält Ihre vorhandenen Keyposes, sodass Sie z. B. früh ein Pop In und später ein Pop Out im selben Clip kombinieren können."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Aplicar en la posición de reproducción</accent> - el botón de insertar coloca el movimiento del preajuste en la posición de reproducción y conserva tus poses clave existentes, así puedes combinar una Aparición pop al principio y una Desaparición pop más tarde en el mismo clip."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Appliquer à la tête de lecture</accent> - le bouton d'insertion place le mouvement du préréglage à la tête de lecture et conserve vos poses clés existantes, ce qui permet de combiner une Apparition pop au début et une Disparition pop plus tard sur le même plan."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>再生ヘッドに適用</accent> - 挿入ボタンはプリセットの動きを再生ヘッドの位置に挿入し、既存のキーポーズはそのまま残します。同じクリップで前半にポップイン、後半にポップアウトを重ねられます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>재생 헤드에 적용</accent> - 삽입 버튼은 프리셋의 움직임을 재생 헤드 위치에 넣고 기존 키포즈를 유지합니다. 그래서 같은 클립에서 앞쪽에 팝 인, 뒤쪽에 팝 아웃을 쌓을 수 있습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>在播放头处应用</accent> - 插入按钮会在播放头处放入预设的动作并保留你已有的关键姿势，因此你可以在同一片段上先弹入、稍后再弹出。"
+          }
+        }
+      }
+    },
+    "<accent>Save</accent> - type a name in the field and press <kbd>+</kbd> to save the current animation as your own preset.": {
+      "comment": "Help text.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Sichern</accent> - geben Sie einen Namen in das Feld ein und drücken Sie <kbd>+</kbd>, um die aktuelle Animation als eigenes Preset zu sichern."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Guardar</accent> - escribe un nombre en el campo y pulsa <kbd>+</kbd> para guardar la animación actual como tu propio preajuste."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Enregistrer</accent> - saisissez un nom dans le champ et appuyez sur <kbd>+</kbd> pour enregistrer l'animation actuelle comme votre propre préréglage."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>保存</accent> - フィールドに名前を入力し、<kbd>+</kbd> を押すと、現在のアニメーションを自分のプリセットとして保存できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>저장</accent> - 필드에 이름을 입력하고 <kbd>+</kbd>를 누르면 현재 애니메이션을 내 프리셋으로 저장합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>保存</accent> - 在字段中输入名称并按 <kbd>+</kbd>，即可将当前动画保存为你自己的预设。"
+          }
+        }
+      }
+    },
+    "<accent>Filter</accent> - type in the same field to narrow the list.": {
+      "comment": "Help text.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Filtern</accent> - tippen Sie in dasselbe Feld, um die Liste einzugrenzen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Filtrar</accent> - escribe en el mismo campo para acotar la lista."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Filtrer</accent> - saisissez du texte dans le même champ pour réduire la liste."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>絞り込み</accent> - 同じフィールドに入力するとリストを絞り込めます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>필터</accent> - 같은 필드에 입력하면 목록을 좁힐 수 있습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>筛选</accent> - 在同一字段中输入即可缩小列表范围。"
+          }
+        }
+      }
+    },
+    "<accent>Manage</accent> - rename, overwrite with the current animation, or delete your own presets (built-ins can't be changed).": {
+      "comment": "Help text.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Verwalten</accent> - benennen Sie Ihre eigenen Presets um, überschreiben Sie sie mit der aktuellen Animation oder löschen Sie sie (integrierte lassen sich nicht ändern)."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Gestionar</accent> - cambia el nombre de tus preajustes, sobrescríbelos con la animación actual o elimínalos (los integrados no se pueden cambiar)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Gérer</accent> - renommez vos préréglages, remplacez-les par l'animation actuelle ou supprimez-les (les intégrés ne sont pas modifiables)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>管理</accent> - 自分のプリセットの名前を変更したり、現在のアニメーションで上書きしたり、削除したりできます（組み込みは変更できません）。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>관리</accent> - 내 프리셋의 이름을 변경하거나 현재 애니메이션으로 덮어쓰거나 삭제할 수 있습니다(기본 제공 항목은 변경할 수 없습니다)."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>管理</accent> - 重命名、用当前动画覆盖或删除你自己的预设（内置预设无法更改）。"
+          }
+        }
+      }
+    },
+    "Apply, insert, and save animations": {
+      "comment": "Help guide subtitle: Presets.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Animationen anwenden, einfügen und sichern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplica, inserta y guarda animaciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appliquer, insérer et enregistrer des animations"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アニメーションの適用・挿入・保存"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "애니메이션 적용, 삽입, 저장"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用、插入和保存动画"
+          }
+        }
+      }
+    },
+    "Click a preset to apply it - it replaces the current animation.": {
+      "comment": "Presets guide step: apply.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klicken Sie auf ein Preset, um es anzuwenden - es ersetzt die aktuelle Animation."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haz clic en un preajuste para aplicarlo - reemplaza la animación actual."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cliquez sur un préréglage pour l'appliquer - il remplace l'animation actuelle."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プリセットをクリックして適用します。現在のアニメーションが置き換わります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프리셋을 클릭하면 적용됩니다 - 현재 애니메이션을 대체합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击预设即可应用 - 它会替换当前动画。"
+          }
+        }
+      }
+    },
+    "This inserts the preset at the playhead instead, keeping your existing keyposes.": {
+      "comment": "Presets guide step: insert at playhead.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiermit wird das Preset stattdessen an der Abspielposition eingefügt und Ihre vorhandenen Keyposes bleiben erhalten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto inserta el preajuste en la posición de reproducción y conserva tus poses clave existentes."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ceci insère plutôt le préréglage à la tête de lecture en conservant vos poses clés existantes."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これはプリセットを再生ヘッドの位置に挿入し、既存のキーポーズを残します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 버튼은 프리셋을 재생 헤드 위치에 삽입하며 기존 키포즈를 유지합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此操作改为在播放头处插入预设，并保留你已有的关键姿势。"
+          }
+        }
+      }
+    },
+    "To save your own, type a name here and press +.": {
+      "comment": "Presets guide step: save.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um ein eigenes zu sichern, geben Sie hier einen Namen ein und drücken +."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para guardar el tuyo, escribe un nombre aquí y pulsa +."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pour enregistrer le vôtre, saisissez un nom ici et appuyez sur +."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自分のものを保存するには、ここに名前を入力して + を押します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "직접 저장하려면 여기에 이름을 입력하고 +를 누르세요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要保存自己的预设，在此输入名称并按 +。"
+          }
+        }
+      }
+    },
+    "Presets let you reuse a move across clips and projects - build it once, apply it anywhere.": {
+      "comment": "Presets guide step: closing value statement.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit Presets verwenden Sie eine Bewegung über Clips und Projekte hinweg wieder - einmal erstellen, überall anwenden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los preajustes te permiten reutilizar un movimiento entre clips y proyectos - créalo una vez y aplícalo donde quieras."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les préréglages permettent de réutiliser un mouvement entre plans et projets - créez-le une fois, appliquez-le partout."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プリセットを使えば、クリップやプロジェクトをまたいで動きを再利用できます。一度作れば、どこでも適用できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프리셋을 사용하면 클립과 프로젝트 전반에서 동작을 재사용할 수 있습니다 - 한 번 만들어 어디서나 적용하세요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预设让你在不同片段和项目间重复使用同一动作 - 制作一次，随处应用。"
+          }
+        }
+      }
+    },
+    "Open your presets to get started.": {
+      "comment": "Presets guide step: open the popover.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnen Sie zuerst Ihre Presets."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre tus preajustes para empezar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez vos préréglages pour commencer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まずプリセットを開きます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시작하려면 프리셋을 여세요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "先打开你的预设。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/KeyframelessKit/KeyframelessKit/Resources/KKLocalizable.xcstrings
+++ b/KeyframelessKit/KeyframelessKit/Resources/KKLocalizable.xcstrings
@@ -8190,6 +8190,846 @@
           }
         }
       }
+    },
+    "Presets": {
+      "comment": "Section title: saved animation presets.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Presets"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preajustes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Préréglages"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プリセット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프리셋"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预设"
+          }
+        }
+      }
+    },
+    "Preset library": {
+      "comment": "Accessibility: open the saved animation preset library.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preset-Bibliothek"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biblioteca de preajustes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bibliothèque de préréglages"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プリセットライブラリ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프리셋 라이브러리"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预设库"
+          }
+        }
+      }
+    },
+    "Default": {
+      "comment": "Badge on a built-in (shipped) preset; also the preset filter for built-ins.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par défaut"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认"
+          }
+        }
+      }
+    },
+    "All": {
+      "comment": "Preset filter: show all presets.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部"
+          }
+        }
+      }
+    },
+    "Mine": {
+      "comment": "Preset filter: show only user-saved presets.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigene"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Míos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les miens"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自分"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내 항목"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我的"
+          }
+        }
+      }
+    },
+    "No presets saved": {
+      "comment": "Empty state for the preset list.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Presets gesichert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay preajustes guardados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun préréglage enregistré"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存されたプリセットはありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장된 프리셋이 없습니다"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未保存预设"
+          }
+        }
+      }
+    },
+    "Name": {
+      "comment": "Placeholder for the new-preset name field.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称"
+          }
+        }
+      }
+    },
+    "Save preset": {
+      "comment": "Accessibility: save the current animation as a preset.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preset sichern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar preajuste"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer le préréglage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プリセットを保存"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프리셋 저장"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存预设"
+          }
+        }
+      }
+    },
+    "Rename preset": {
+      "comment": "Accessibility: rename the saved preset.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preset umbenennen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar nombre del preajuste"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer le préréglage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プリセットの名前を変更"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프리셋 이름 변경"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名预设"
+          }
+        }
+      }
+    },
+    "Overwrite preset with current animation": {
+      "comment": "Accessibility: replace a saved preset with the current animation.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preset mit aktueller Animation überschreiben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sobrescribir el preajuste con la animación actual"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remplacer le préréglage par l'animation actuelle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のアニメーションでプリセットを上書き"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 애니메이션으로 프리셋 덮어쓰기"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用当前动画覆盖预设"
+          }
+        }
+      }
+    },
+    "Delete preset": {
+      "comment": "Accessibility: delete the saved preset.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preset löschen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar preajuste"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer le préréglage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プリセットを削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프리셋 삭제"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除预设"
+          }
+        }
+      }
+    },
+    "Pop In": {
+      "comment": "Built-in preset name: scale + opacity grow in.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pop In"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aparición pop"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apparition pop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ポップイン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "팝 인"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "弹入"
+          }
+        }
+      }
+    },
+    "Pop Out": {
+      "comment": "Built-in preset name: scale + opacity shrink out.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pop Out"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desaparición pop"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disparition pop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ポップアウト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "팝 아웃"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "弹出"
+          }
+        }
+      }
+    },
+    "Pop In-Out": {
+      "comment": "Built-in preset name: pop in then pop out.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pop In-Out"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aparición y desaparición pop"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apparition et disparition pop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ポップイン・アウト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "팝 인-아웃"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "弹入弹出"
+          }
+        }
+      }
+    },
+    "Round In": {
+      "comment": "Built-in preset name: corner radius grows in.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrunden ein"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redondear entrada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrondi entrant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ラウンドイン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라운드 인"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圆角渐入"
+          }
+        }
+      }
+    },
+    "Round Out": {
+      "comment": "Built-in preset name: corner radius shrinks out.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrunden aus"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redondear salida"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrondi sortant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ラウンドアウト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라운드 아웃"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圆角渐出"
+          }
+        }
+      }
+    },
+    "Apply preset at playhead": {
+      "comment": "Accessibility: insert the preset's animation at the current playhead, keeping existing keyposes.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preset an der Abspielposition anwenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar el preajuste en la posición de reproducción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appliquer le préréglage à la tête de lecture"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再生ヘッドの位置にプリセットを適用"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "재생 헤드 위치에 프리셋 적용"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在播放头处应用预设"
+          }
+        }
+      }
+    },
+    "Filter or name": {
+      "comment": "Placeholder: type to filter the preset list, or to name a new preset.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtern oder benennen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar o nombrar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrer ou nommer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "絞り込み / 名前"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "필터 또는 이름"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "筛选或命名"
+          }
+        }
+      }
+    },
+    "No matches": {
+      "comment": "Empty state when a preset filter matches nothing.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Treffer"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin coincidencias"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun résultat"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致なし"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일치 항목 없음"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无匹配项"
+          }
+        }
+      }
+    },
+    "Apply preset (replace)": {
+      "comment": "Tooltip: clicking a preset row replaces the current animation.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preset anwenden (ersetzen)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar preajuste (reemplazar)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appliquer le préréglage (remplacer)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プリセットを適用（置き換え）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프리셋 적용 (대체)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用预设（替换）"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/KeyframelessKit/KeyframelessKit/Resources/KKLocalizable.xcstrings
+++ b/KeyframelessKit/KeyframelessKit/Resources/KKLocalizable.xcstrings
@@ -9576,6 +9576,48 @@
           }
         }
       }
+    },
+    "<accent>Fixed transitions</accent> - a preset saves its transitions (the moving parts) as fixed durations and its holds as flexible, so an applied preset feels the same whether the clip is short or long.": {
+      "comment": "Help text.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Feste Übergänge</accent> - ein Preset sichert seine Übergänge (die bewegten Teile) mit fester Dauer und seine Haltephasen flexibel, sodass sich ein angewendetes Preset bei kurzen wie langen Clips gleich anfühlt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Transiciones fijas</accent> - un preajuste guarda sus transiciones (las partes en movimiento) con una duración fija y sus mantenimientos de forma flexible, de modo que un preajuste aplicado se siente igual tanto en un clip corto como en uno largo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>Transitions fixes</accent> - un préréglage enregistre ses transitions (les parties en mouvement) avec une durée fixe et ses maintiens de façon flexible, afin qu'un préréglage appliqué donne le même ressenti que le plan soit court ou long."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>固定トランジション</accent> - プリセットはトランジション（動く部分）を固定の長さで、ホールドを可変で保存するため、適用したプリセットはクリップが短くても長くても同じ印象になります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>고정 트랜지션</accent> - 프리셋은 트랜지션(움직이는 부분)을 고정된 길이로, 홀드를 유연하게 저장하므로 적용한 프리셋은 클립이 짧든 길든 동일하게 느껴집니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "<accent>固定过渡</accent> - 预设会将其过渡（运动部分）保存为固定时长，而将保持段保存为可变，因此应用的预设无论片段长短都能保持相同的感觉。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/KeyframelessKit/KeyframelessKit/Resources/TimelineKnowledge/basic-vs-advanced.md
+++ b/KeyframelessKit/KeyframelessKit/Resources/TimelineKnowledge/basic-vs-advanced.md
@@ -3,8 +3,7 @@ id: basic-vs-advanced
 summary: Basic timing vs Advanced timing modes
 ---
 
-Every property has two timing modes, switched with the pill at the top of its row:
-
+- Every property has two timing modes, switched with the pill at the top of its row:
   - **Basic** - three checkboxed phases (**In**, **Hold**, **Out**) for a simple ease-in, hold, ease-out. Drag the hold boundary to move where In ends and Out begins.
   - **Advanced** - the full keyposes + intervals model: any number of keyposes, each interval with its own curve and modulation. Use it for multi-step motion or custom holds.
 

--- a/KeyframelessKit/KeyframelessKit/Resources/TimelineKnowledge/easing.md
+++ b/KeyframelessKit/KeyframelessKit/Resources/TimelineKnowledge/easing.md
@@ -3,8 +3,7 @@ id: easing
 summary: Easing curves on intervals (Linear, Ease, Elastic, Bounce)
 ---
 
-Each Advanced interval has an easing curve. Click the interval to pick it (Shift-click to select several first):
-
+- Each Advanced interval has an easing curve. Click the interval to pick it (Shift-click to select several first):
   - **Linear** - uniform motion.
   - **Ease In** - slow start, accelerates.
   - **Ease Out** - fast start, decelerates.

--- a/KeyframelessKit/KeyframelessKit/Resources/TimelineKnowledge/presets.md
+++ b/KeyframelessKit/KeyframelessKit/Resources/TimelineKnowledge/presets.md
@@ -1,0 +1,25 @@
+---
+id: presets
+summary: Save an animation and re-apply it to any clip (built-in and custom presets)
+---
+
+Save an animation you like and re-apply it to any clip from the **Presets** row:
+
+- **Default presets** - built-in starters like Pop In and Pop Out, marked with a Default badge. They are read-only.
+- **Apply** - click a preset to replace the current animation with it.
+- **Apply at playhead** - the insert button drops the preset's move in at the playhead and keeps your existing keyposes, so you can stack a Pop In early and a Pop Out later on the same clip.
+- **Save** - type a name in the field and press `+` to save the current animation as your own preset.
+- **Filter** - type in the same field to narrow the list.
+- **Manage** - rename, overwrite with the current animation, or delete your own presets (built-ins can't be changed).
+
+## How preset timing adapts
+
+A preset stores its transitions as fixed durations and its holds as flexible. When you apply it, each move keeps the same length in seconds while the holds stretch or shrink to fill the clip - so a Pop In feels the same on a one-second title and a ten-second one. The animation is also fit to the clip's last reachable frame.
+
+## Applying at the playhead
+
+The insert button merges the preset in starting at the current playhead instead of replacing everything: keyposes before the playhead are kept, the preset's animated lanes are placed from the playhead onward, and any redundant hold keypose at the join is removed. Only the lanes the preset actually animates are touched - unused properties are left alone.
+
+## Basic and Advanced
+
+Presets work in both Basic and Advanced. If a preset is too rich for Basic to show (for example it animates several properties at once), applying it switches the inspector to Advanced so you see the real result.

--- a/KeyframelessKit/KeyframelessKit/Resources/TimelineKnowledge/presets.md
+++ b/KeyframelessKit/KeyframelessKit/Resources/TimelineKnowledge/presets.md
@@ -3,14 +3,14 @@ id: presets
 summary: Save an animation and re-apply it to any clip (built-in and custom presets)
 ---
 
-Save an animation you like and re-apply it to any clip from the **Presets** row:
-
-- **Default presets** - built-in starters like Pop In and Pop Out, marked with a Default badge. They are read-only.
-- **Apply** - click a preset to replace the current animation with it.
-- **Apply at playhead** - the insert button drops the preset's move in at the playhead and keeps your existing keyposes, so you can stack a Pop In early and a Pop Out later on the same clip.
-- **Save** - type a name in the field and press `+` to save the current animation as your own preset.
-- **Filter** - type in the same field to narrow the list.
-- **Manage** - rename, overwrite with the current animation, or delete your own presets (built-ins can't be changed).
+- Save an animation you like and re-apply it to any clip from the **Presets** row:
+  - **Default presets** - built-in starters like Pop In and Pop Out, marked with a Default badge. They are read-only.
+  - **Apply** - click a preset to replace the current animation with it.
+  - **Apply at playhead** - the insert button drops the preset's move in at the playhead and keeps your existing keyposes, so you can stack a Pop In early and a Pop Out later on the same clip.
+  - **Save** - type a name in the field and press `+` to save the current animation as your own preset.
+  - **Fixed transitions** - a preset saves its transitions (the moving parts) as fixed durations and its holds as flexible, so an applied preset feels the same whether the clip is short or long.
+  - **Filter** - type in the same field to narrow the list.
+  - **Manage** - rename, overwrite with the current animation, or delete your own presets (built-ins can't be changed).
 
 ## How preset timing adapts
 

--- a/KeyframelessKit/KeyframelessKit/Resources/TimelineKnowledge/timeline-basics.md
+++ b/KeyframelessKit/KeyframelessKit/Resources/TimelineKnowledge/timeline-basics.md
@@ -3,8 +3,7 @@ id: timeline-basics
 summary: How animation works (lanes, keyposes, intervals, linked endpoints)
 ---
 
-Animation is built from three things:
-
+- Animation is built from three things:
   - **Lanes** - one per animatable property (Position, Radius, Color...). Toggle a lane on to animate it, off to hold a constant. The lane list is on the left.
   - **Keyposes** - a value at a point in time, shown as a pill on the lane. Place them wherever the motion should pass through.
   - **Intervals** - the gap between two keyposes. Each carries its own easing curve and optional modulation. Link the endpoints to make the interval a flat hold.

--- a/KeyframelessKit/KeyframelessKit/Resources/builtin_presets.json
+++ b/KeyframelessKit/KeyframelessKit/Resources/builtin_presets.json
@@ -1,0 +1,220 @@
+{
+  "MagicMove-XPC-Service": [
+    {
+      "id": "D92B3463-9D79-4C81-B194-42735E3DB8F4",
+      "name": "Pop In",
+      "timeline": {
+        "version": 1,
+        "groups": [],
+        "lanes": [
+          {
+            "id": "E39744D9-116A-43DB-86FB-5D4DA371A293",
+            "label": "Position",
+            "enabled": false,
+            "value_type": 0,
+            "component_min": [],
+            "component_max": [],
+            "component_units": ["px", "px"],
+            "component_labels": ["X", "Y"],
+            "spatial_curvable": true,
+            "keyposes": [{ "time": 0.0, "values": [0.5, 0.5] }]
+          },
+          {
+            "id": "20FCBC86-3480-48F8-99BD-4AD352249ADD",
+            "label": "Scale",
+            "value_type": 1,
+            "component_min": [0.0, 0.0],
+            "component_max": [],
+            "component_units": ["%", "%"],
+            "component_labels": ["X", "Y"],
+            "integer_valued": true,
+            "aspect_linkable": true,
+            "aspect_linked": true,
+            "hold_shape": 2,
+            "keyposes": [
+              { "time": 0.0, "values": [0.0, 0.0], "outgoing": { "curve": 2, "locked_seconds": 0.4 } },
+              { "time": 0.3, "values": [100.0, 100.0], "outgoing": {} },
+              { "time": 1.0, "values": [100.0, 100.0] }
+            ]
+          },
+          {
+            "id": "014376D2-58A3-4ACA-B412-3BEEE053EFC3",
+            "label": "Rotation",
+            "enabled": false,
+            "value_type": 6,
+            "component_min": [],
+            "component_max": [],
+            "component_units": ["°", "°", "°"],
+            "component_labels": ["X", "Y", "Z"],
+            "keyposes": [{ "time": 0.0, "values": [0.0, 0.0, 0.0] }]
+          },
+          {
+            "id": "FFB8B724-F665-4506-B306-EC800AC66F1D",
+            "label": "Opacity",
+            "enabled": false,
+            "value_type": 1,
+            "component_min": [0.0],
+            "component_max": [100.0],
+            "component_units": ["%"],
+            "integer_valued": true,
+            "keyposes": [{ "time": 0.0, "values": [100.0] }]
+          },
+          {
+            "id": "C71960E3-12EC-4405-B560-F3B243122FB9",
+            "label": "Anchor",
+            "enabled": false,
+            "value_type": 0,
+            "component_min": [],
+            "component_max": [],
+            "component_units": ["px", "px"],
+            "component_labels": ["X", "Y"],
+            "keyposes": [{ "time": 0.0, "values": [0.5, 0.5] }]
+          }
+        ]
+      }
+    },
+    {
+      "id": "7E96819F-5720-4320-8AF9-90F409936302",
+      "name": "Pop Out",
+      "timeline": {
+        "version": 1,
+        "groups": [],
+        "lanes": [
+          {
+            "id": "0F1E871F-8F04-4996-83EE-C2A37CF35CCA",
+            "label": "Position",
+            "enabled": false,
+            "value_type": 0,
+            "component_min": [],
+            "component_max": [],
+            "component_units": ["px", "px"],
+            "component_labels": ["X", "Y"],
+            "spatial_curvable": true,
+            "keyposes": [{ "time": 0.0, "values": [0.5, 0.5] }]
+          },
+          {
+            "id": "B47D8EAA-C98C-43E3-BDC4-3825182FAD83",
+            "label": "Scale",
+            "value_type": 1,
+            "component_min": [0.0, 0.0],
+            "component_max": [],
+            "component_units": ["%", "%"],
+            "component_labels": ["X", "Y"],
+            "integer_valued": true,
+            "aspect_linkable": true,
+            "aspect_linked": true,
+            "hold_shape": 3,
+            "keyposes": [
+              { "time": 0.0, "values": [100.0, 100.0], "outgoing": {} },
+              { "time": 0.7, "values": [100.0, 100.0], "outgoing": { "curve": 1, "locked_seconds": 0.4 } },
+              { "time": 1.0, "values": [0.0, 0.0] }
+            ]
+          },
+          {
+            "id": "8E4E52BD-0193-460F-A105-210701D3754A",
+            "label": "Rotation",
+            "enabled": false,
+            "value_type": 6,
+            "component_min": [],
+            "component_max": [],
+            "component_units": ["°", "°", "°"],
+            "component_labels": ["X", "Y", "Z"],
+            "keyposes": [{ "time": 0.0, "values": [0.0, 0.0, 0.0] }]
+          },
+          {
+            "id": "9A369BDD-8BBD-4E7F-B4C3-B3D5CD222373",
+            "label": "Opacity",
+            "enabled": false,
+            "value_type": 1,
+            "component_min": [0.0],
+            "component_max": [100.0],
+            "component_units": ["%"],
+            "integer_valued": true,
+            "keyposes": [{ "time": 0.0, "values": [100.0] }]
+          },
+          {
+            "id": "92744E38-CD29-4074-89B6-7551D4E2F135",
+            "label": "Anchor",
+            "enabled": false,
+            "value_type": 0,
+            "component_min": [],
+            "component_max": [],
+            "component_units": ["px", "px"],
+            "component_labels": ["X", "Y"],
+            "keyposes": [{ "time": 0.0, "values": [0.5, 0.5] }]
+          }
+        ]
+      }
+    }
+  ],
+  "Rounded-XPC-Service": [
+    {
+      "id": "C9D1AAFC-05E2-48FD-A659-2AC4B0E073BC",
+      "name": "Round In",
+      "timeline": {
+        "version": 1,
+        "groups": [],
+        "lanes": [
+          {
+            "id": "0048AAFE-A082-4D91-ABD6-BB22509F5E3F",
+            "label": "Radius",
+            "value_type": 1,
+            "component_min": [0.0],
+            "component_max": [100.0],
+            "component_units": ["%"],
+            "hold_shape": 2,
+            "keyposes": [
+              { "time": 0.0, "values": [0.0], "outgoing": { "curve": 2, "locked_seconds": 0.4 } },
+              { "time": 0.3, "values": [100.0], "outgoing": {} },
+              { "time": 1.0, "values": [100.0] }
+            ]
+          },
+          {
+            "id": "22403FCD-1607-400E-BB38-5B15C6D80DAA",
+            "label": "Crop",
+            "enabled": false,
+            "value_type": 3,
+            "component_min": [0.0, 0.0, -0.5, -0.5],
+            "component_max": [1.0, 1.0, 0.5, 0.5],
+            "component_units": ["px", "px", "px", "px"],
+            "keyposes": [{ "time": 0.0, "values": [1.0, 1.0, 0.0, 0.0] }]
+          }
+        ]
+      }
+    },
+    {
+      "id": "0C08AF04-1247-42F6-B3DF-1B0EFF80C7E8",
+      "name": "Round Out",
+      "timeline": {
+        "version": 1,
+        "groups": [],
+        "lanes": [
+          {
+            "id": "021FD994-83A1-4C46-80BE-5994165A058C",
+            "label": "Radius",
+            "value_type": 1,
+            "component_min": [0.0],
+            "component_max": [100.0],
+            "component_units": ["%"],
+            "hold_shape": 3,
+            "keyposes": [
+              { "time": 0.0, "values": [100.0], "outgoing": {} },
+              { "time": 0.7, "values": [100.0], "outgoing": { "curve": 1, "locked_seconds": 0.4 } },
+              { "time": 1.0, "values": [0.0] }
+            ]
+          },
+          {
+            "id": "E73C3409-6616-48F6-9F62-4B93464E3158",
+            "label": "Crop",
+            "enabled": false,
+            "value_type": 3,
+            "component_min": [0.0, 0.0, -0.5, -0.5],
+            "component_max": [1.0, 1.0, 0.5, 0.5],
+            "component_units": ["px", "px", "px", "px"],
+            "keyposes": [{ "time": 0.0, "values": [1.0, 1.0, 0.0, 0.0] }]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/KeyframelessKit/KeyframelessKit/Views/Controls/Fields/KKValueTextField.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Controls/Fields/KKValueTextField.m
@@ -66,8 +66,33 @@
   _inMouseDown = NO;
 }
 - (BOOL)performKeyEquivalent:(NSEvent *)event {
-  if (self.currentEditor) {
-    [self.currentEditor keyDown:event];
+  NSText *editor = self.currentEditor;
+  // In an FxPlug ViewBridge popover there's no Edit menu, so the standard
+  // Cmd-A / C / V / X key equivalents never route to the field editor. Dispatch
+  // them to it explicitly while we're being edited.
+  if (editor &&
+      (event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask) ==
+          NSEventModifierFlagCommand) {
+    NSString *key = event.charactersIgnoringModifiers.lowercaseString;
+    if ([key isEqualToString:@"a"]) {
+      [editor selectAll:nil];
+      return YES;
+    }
+    if ([key isEqualToString:@"c"]) {
+      [editor copy:nil];
+      return YES;
+    }
+    if ([key isEqualToString:@"v"]) {
+      [editor paste:nil];
+      return YES;
+    }
+    if ([key isEqualToString:@"x"]) {
+      [editor cut:nil];
+      return YES;
+    }
+  }
+  if (editor) {
+    [editor keyDown:event];
     return YES;
   }
   return [super performKeyEquivalent:event];

--- a/KeyframelessKit/KeyframelessKit/Views/Joyride/Steps/KKTimingGuide.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Joyride/Steps/KKTimingGuide.m
@@ -7,6 +7,7 @@
 
 #import "KKEasing.h"
 #import "KKLocalized.h"
+#import "KKTimelineInspectorView+Presets.h"
 #import <KeyframelessKit/KKHelpSection.h>
 #import <KeyframelessKit/KKJoyrideController.h>
 #import <KeyframelessKit/KKJoyrideDragStep.h>
@@ -127,6 +128,26 @@ static const CGFloat kDragSnapPx = 14.0;
   weakOSC = osc;
   osc.identifier = @"osc";
 
+  __block __weak KKHelpGuide *weakPresets = nil;
+  KKHelpGuide *presets = [KKHelpGuide
+      guideWithTitle:KKLoc(@"Presets",
+                           @"Help guide title: presets walkthrough.")
+            subtitle:KKLoc(@"Apply, insert, and save animations",
+                           @"Help guide subtitle: Presets.")
+             onStart:^{
+               KKTimelineInspectorView *iv =
+                   inspectorProvider ? inspectorProvider() : nil;
+               if (!iv)
+                 return;
+               KKHelpGuide *live = weakPresets;
+               iv.onGuideCompleted = ^{
+                 [live markCompleted];
+               };
+               [iv runPresetsGuide];
+             }];
+  weakPresets = presets;
+  presets.identifier = @"presets";
+
   // The guides cut out the FCP viewer / boundary popover, which only resolve
   // once the OSC bridge has a draw tick - so they gate on the same canvas
   // reference the plugin supplies.
@@ -135,11 +156,11 @@ static const CGFloat kDragSnapPx = 14.0;
             @"select it (it highlights yellow), then move your mouse over the "
             @"viewer to enable them.",
             @"Help guide disabled subtitle (no OSC canvas reference yet).");
-  for (KKHelpGuide *g in @[ intro, advanced, miniViewer, osc ]) {
+  for (KKHelpGuide *g in @[ intro, advanced, miniViewer, osc, presets ]) {
     g.enabledProvider = enabledProvider;
     g.disabledSubtitle = disabled;
   }
-  return @[ intro, advanced, miniViewer, osc ];
+  return @[ intro, advanced, miniViewer, osc, presets ];
 }
 
 + (KKTimeline *)basicSeedTimelineForConfig:(KKTimingGuideConfig *)config {

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Advanced/KKTimelineAdvancedView+Drawing.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Advanced/KKTimelineAdvancedView+Drawing.m
@@ -82,12 +82,15 @@ double KKAdvNormComponent(double v, NSArray<NSNumber *> *cMin,
   }
 
   // Curves and pills get clipped to the tracks rect so zoom/pan content
-  // doesn't bleed into the label gutter or beyond the track edges. Clip is
-  // expanded so t=0 / t=1 pills draw whole + ~2px for the selection halo.
+  // doesn't bleed into the label gutter or beyond the track edges. The left
+  // edge keeps a small pad so the t=0 pill + halo draw whole; the right edge
+  // runs out to the container edge so the last-frame pill and its selection
+  // halo overflow whole into the free right gutter, the same way the playhead
+  // knob overflows.
   CGFloat edgePad = kPillW * 0.5 + 2.0;
+  CGFloat clipL = NSMinX(tracks) - edgePad;
   [NSGraphicsContext saveGraphicsState];
-  NSRectClip(NSMakeRect(NSMinX(tracks) - edgePad, NSMinY(g),
-                        NSWidth(tracks) + edgePad * 2.0, NSHeight(g)));
+  NSRectClip(NSMakeRect(clipL, NSMinY(g), NSMaxX(g) - clipL, NSHeight(g)));
   for (NSInteger i = 0; i < (NSInteger)lanes.count; i++) {
     KKLane *lane = lanes[i];
     NSRect row = [self _rowRectForIndex:i count:lanes.count];

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Advanced/KKTimelineAdvancedView+Interaction.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Advanced/KKTimelineAdvancedView+Interaction.m
@@ -12,9 +12,13 @@
 @implementation KKTimelineAdvancedView (Interaction)
 
 - (BOOL)_isInScrubBand:(NSPoint)pt {
+  NSRect g = [self _graphRect];
   NSRect tracks = [self _tracksRect];
-  return KKTimelineScrubBandContainsPoint(pt, NSMinX(tracks), NSMaxX(tracks),
-                                          NSMaxY([self _graphRect]));
+  // Right edge runs out to the container edge, not NSMaxX(tracks), so the right
+  // gutter where the last-frame pill draws stays scrubbable like the rest of
+  // the ruler; _fracForX clamps those clicks to lastFrameFrac (the last pill).
+  return KKTimelineScrubBandContainsPoint(pt, NSMinX(tracks), NSMaxX(g),
+                                          NSMaxY(g));
 }
 
 // Drag snap: every animatable KP time (across all lanes) is a candidate,

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Advanced/KKTimelineAdvancedView+Model.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Advanced/KKTimelineAdvancedView+Model.m
@@ -107,7 +107,11 @@
   double vf = pan + (x - NSMinX(t)) / (NSWidth(t) * z);
   double lf = [self _lastFrameFrac];
   double f = lf < 1.0 ? vf * lf : vf;
-  return f < 0.0 ? 0.0 : (f > 1.0 ? 1.0 : f);
+  // Clamp to the last renderable frame (the visual right edge where the final
+  // pill parks), not 1.0 - otherwise scrub + snap run past the last pill into
+  // the one-frame out-point overshoot.
+  double hi = lf < 1.0 ? lf : 1.0;
+  return f < 0.0 ? 0.0 : (f > hi ? hi : f);
 }
 
 - (CGFloat)_rowHeightForCount:(NSInteger)n {

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Basic/KKTimelineBasicView+Interaction.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Basic/KKTimelineBasicView+Interaction.m
@@ -146,7 +146,12 @@ static const CGFloat kScrubSnapInPx = 4.0;
 }
 
 - (BOOL)_isInScrubBand:(NSPoint)pt rect:(NSRect)g {
-  return KKTimelineScrubBandContainsPoint(pt, NSMinX(g), NSMaxX(g), NSMaxY(g));
+  // Right edge runs out to the container edge, not NSMaxX(g), so the right
+  // gutter where the out-end pill draws stays scrubbable like the rest of the
+  // ruler; the frac mapping clamps u (and the delivered-frac clamp pins) those
+  // clicks to the last frame (the out-end pill).
+  return KKTimelineScrubBandContainsPoint(
+      pt, NSMinX(g), NSMaxX([self _containerRect]), NSMaxY(g));
 }
 
 - (void)mouseDown:(NSEvent *)event {

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetRowView.h
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetRowView.h
@@ -15,6 +15,10 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT const CGFloat KKPresetPopoverWidth;
 FOUNDATION_EXPORT const CGFloat KKPresetRowHeight;
 
+/// A view's bounds in screen space (empty if not in a window). For guide
+/// spotlight rects.
+FOUNDATION_EXPORT NSRect KKPresetScreenRectForView(NSView *_Nullable v);
+
 /// Top-down layout container so built-ins (added first) render at the top.
 @interface KKPresetsFlippedView : NSView
 @end
@@ -38,6 +42,8 @@ FOUNDATION_EXPORT const CGFloat KKPresetRowHeight;
 @property(nonatomic, copy, nullable) void (^onRename)
     (NSString *identifier, NSString *newName);
 - (instancetype)initWithPreset:(KKPreset *)preset;
+/// Screen rect of the apply-at-playhead (insert) button, for guide spotlights.
+- (NSRect)insertButtonScreenRect;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetRowView.h
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetRowView.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+#pragma once
+
+#import <AppKit/AppKit.h>
+
+@class KKPreset;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Shared layout metrics for the presets popover + its rows.
+FOUNDATION_EXPORT const CGFloat KKPresetPopoverWidth;
+FOUNDATION_EXPORT const CGFloat KKPresetRowHeight;
+
+/// Top-down layout container so built-ins (added first) render at the top.
+@interface KKPresetsFlippedView : NSView
+@end
+
+/// NSTextField that routes Cmd-A / C / V / X to the field editor (no Edit menu
+/// in an FxPlug ViewBridge popover) and tints the caret/selection to the host
+/// accent. Used for both the inline-rename field and the popover filter field.
+@interface KKPresetNameTextField : NSTextField
+@end
+
+/// One preset row: name (inline-renamable for user presets), an accent-tinted
+/// apply-at-playhead button, and either a "Default" badge (built-ins) or
+/// rename / overwrite / delete buttons. Clicking the row body applies as an
+/// override; hovering highlights it and shows a pointing-hand cursor.
+@interface KKPresetRowView : NSView <NSTextFieldDelegate>
+@property(nonatomic, strong) KKPreset *preset;
+@property(nonatomic, copy, nullable) void (^onApply)
+    (KKPreset *preset, BOOL atPlayhead);
+@property(nonatomic, copy, nullable) void (^onDelete)(NSString *identifier);
+@property(nonatomic, copy, nullable) void (^onOverwrite)(NSString *identifier);
+@property(nonatomic, copy, nullable) void (^onRename)
+    (NSString *identifier, NSString *newName);
+- (instancetype)initWithPreset:(KKPreset *)preset;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetRowView.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetRowView.m
@@ -1,0 +1,342 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+#import "KKPresetRowView.h"
+
+#import "KKHelpViewSubviews.h" // _KKCapsuleView (app-wide InfoBadge look)
+#import "KKLocalized.h"
+#import "KKPresets.h"
+#import <KeyframelessKit/KKTokens.h>
+#import <KeyframelessKit/NSColor+KKColors.h>
+
+const CGFloat KKPresetPopoverWidth = 280.0;
+const CGFloat KKPresetRowHeight = 28.0;
+
+@implementation KKPresetsFlippedView
+- (BOOL)isFlipped {
+  return YES;
+}
+@end
+
+@implementation KKPresetNameTextField
+
+- (BOOL)performKeyEquivalent:(NSEvent *)event {
+  NSText *editor = self.currentEditor;
+  // In an FxPlug ViewBridge popover there's no Edit menu, so the standard
+  // Cmd-A / C / V / X key equivalents never route to the field editor. Dispatch
+  // them to it explicitly while we're being edited.
+  if (editor &&
+      (event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask) ==
+          NSEventModifierFlagCommand) {
+    NSString *key = event.charactersIgnoringModifiers.lowercaseString;
+    if ([key isEqualToString:@"a"]) {
+      [editor selectAll:nil];
+      return YES;
+    }
+    if ([key isEqualToString:@"c"]) {
+      [editor copy:nil];
+      return YES;
+    }
+    if ([key isEqualToString:@"v"]) {
+      [editor paste:nil];
+      return YES;
+    }
+    if ([key isEqualToString:@"x"]) {
+      [editor cut:nil];
+      return YES;
+    }
+  }
+  if (editor) {
+    [editor keyDown:event];
+    return YES;
+  }
+  return [super performKeyEquivalent:event];
+}
+
+- (BOOL)becomeFirstResponder {
+  BOOL ok = [super becomeFirstResponder];
+  if (ok) {
+    NSTextView *editor = (NSTextView *)self.currentEditor;
+    NSColor *accent = [NSColor accentMatchingHost];
+    editor.insertionPointColor = accent;
+    editor.selectedTextAttributes = @{
+      NSBackgroundColorAttributeName : [accent colorWithAlphaComponent:0.3],
+      NSForegroundColorAttributeName : [NSColor labelColor],
+    };
+  }
+  return ok;
+}
+
+@end
+
+@implementation KKPresetRowView {
+  NSTextField *_nameField;
+  NSButton *_applyAtButton;
+  NSButton *_renameButton;
+  NSButton *_overwriteButton;
+  NSButton *_deleteButton;
+}
+
+- (instancetype)initWithPreset:(KKPreset *)preset {
+  self = [super
+      initWithFrame:NSMakeRect(0, 0, KKPresetPopoverWidth, KKPresetRowHeight)];
+  if (!self)
+    return nil;
+  _preset = preset;
+  self.wantsLayer = YES; // hover highlight
+  self.toolTip = KKLoc(@"Apply preset (replace)",
+                       @"Tooltip: clicking a preset row replaces the current "
+                       @"animation.");
+
+  _nameField = [[KKPresetNameTextField alloc] initWithFrame:NSZeroRect];
+  _nameField.stringValue = preset.displayName;
+  _nameField.font = [NSFont systemFontOfSize:11.0];
+  _nameField.textColor = [NSColor inspectorLabel];
+  _nameField.lineBreakMode = NSLineBreakByTruncatingTail;
+  _nameField.translatesAutoresizingMaskIntoConstraints = NO;
+  _nameField.editable = NO;
+  _nameField.selectable = NO;
+  _nameField.bordered = NO;
+  _nameField.bezeled = NO;
+  _nameField.drawsBackground = NO;
+  _nameField.focusRingType = NSFocusRingTypeNone;
+  _nameField.delegate = self;
+  _nameField.cell.scrollable = YES;
+  _nameField.cell.wraps = NO;
+  [self addSubview:_nameField];
+
+  NSImageSymbolConfiguration *cfg = [NSImageSymbolConfiguration
+      configurationWithPointSize:10.0
+                          weight:NSFontWeightRegular];
+
+  // Every row carries an "apply at playhead" button; clicking the row body
+  // applies as an override.
+  _applyAtButton = [self
+        _iconButton:@"text.insert"
+      accessibility:KKLoc(@"Apply preset at playhead",
+                          @"Accessibility: insert the preset's animation at "
+                          @"the current playhead, keeping existing keyposes.")
+             config:cfg
+             action:@selector(_applyAtTapped:)];
+  // Accent-tinted (host-matching) so the primary "insert here" action stands
+  // apart from the muted rename/overwrite/delete glyphs.
+  _applyAtButton.contentTintColor = [NSColor accentMatchingHost];
+  [self addSubview:_applyAtButton];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [_nameField.leadingAnchor constraintEqualToAnchor:self.leadingAnchor
+                                             constant:KKPaddingLG],
+    [_nameField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+    [_applyAtButton.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+  ]];
+
+  // Trailing cluster laid out right-to-left; _applyAtButton sits leftmost of
+  // it, and the name field stops before whatever is leftmost.
+  if (preset.builtin) {
+    NSView *badge = [self _buildDefaultBadge];
+    [self addSubview:badge];
+    [NSLayoutConstraint activateConstraints:@[
+      [badge.trailingAnchor constraintEqualToAnchor:self.trailingAnchor
+                                           constant:-KKPaddingLG],
+      [badge.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+      [_applyAtButton.trailingAnchor constraintEqualToAnchor:badge.leadingAnchor
+                                                    constant:-KKSpacingMD],
+    ]];
+  } else {
+    _renameButton =
+        [self _iconButton:@"pencil"
+            accessibility:KKLoc(@"Rename preset",
+                                @"Accessibility: rename the saved preset.")
+                   config:cfg
+                   action:@selector(_renameTapped:)];
+    _overwriteButton = [self
+          _iconButton:@"square.and.arrow.down"
+        accessibility:KKLoc(@"Overwrite preset with current animation",
+                            @"Accessibility: replace a saved preset with the "
+                            @"current animation.")
+               config:cfg
+               action:@selector(_overwriteTapped:)];
+    _deleteButton =
+        [self _iconButton:@"trash"
+            accessibility:KKLoc(@"Delete preset",
+                                @"Accessibility: delete the saved preset.")
+                   config:cfg
+                   action:@selector(_deleteTapped:)];
+    [self addSubview:_renameButton];
+    [self addSubview:_overwriteButton];
+    [self addSubview:_deleteButton];
+
+    [NSLayoutConstraint activateConstraints:@[
+      [_deleteButton.trailingAnchor constraintEqualToAnchor:self.trailingAnchor
+                                                   constant:-KKPaddingLG],
+      [_deleteButton.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+      [_overwriteButton.trailingAnchor
+          constraintEqualToAnchor:_deleteButton.leadingAnchor
+                         constant:-KKSpacingMD],
+      [_overwriteButton.centerYAnchor
+          constraintEqualToAnchor:self.centerYAnchor],
+      [_renameButton.trailingAnchor
+          constraintEqualToAnchor:_overwriteButton.leadingAnchor
+                         constant:-KKSpacingMD],
+      [_renameButton.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+      [_applyAtButton.trailingAnchor
+          constraintEqualToAnchor:_renameButton.leadingAnchor
+                         constant:-KKSpacingMD],
+    ]];
+  }
+  [_nameField.trailingAnchor
+      constraintLessThanOrEqualToAnchor:_applyAtButton.leadingAnchor
+                               constant:-KKSpacingSM]
+      .active = YES;
+  return self;
+}
+
+- (NSButton *)_iconButton:(NSString *)symbol
+            accessibility:(NSString *)accessibility
+                   config:(NSImageSymbolConfiguration *)cfg
+                   action:(SEL)action {
+  NSImage *img = [[NSImage imageWithSystemSymbolName:symbol
+                            accessibilityDescription:accessibility]
+      imageWithSymbolConfiguration:cfg];
+  NSButton *button = [NSButton buttonWithImage:img target:self action:action];
+  button.bordered = NO;
+  button.contentTintColor =
+      [NSColor.inspectorLabel colorWithAlphaComponent:0.4];
+  button.toolTip = accessibility;
+  button.translatesAutoresizingMaskIntoConstraints = NO;
+  [NSLayoutConstraint activateConstraints:@[
+    [button.widthAnchor constraintEqualToConstant:16.0],
+    [button.heightAnchor constraintEqualToConstant:16.0],
+  ]];
+  return button;
+}
+
+// Matches the docs window / app-wide InfoBadge: self-rounding capsule,
+// inspectorLabel fill at 15%, label at 60% in 9pt medium.
+- (NSView *)_buildDefaultBadge {
+  NSColor *badgeColor = [[NSColor inspectorLabel] colorWithAlphaComponent:0.6];
+  _KKCapsuleView *badge = [[_KKCapsuleView alloc] initWithFrame:NSZeroRect];
+  badge.translatesAutoresizingMaskIntoConstraints = NO;
+  badge.wantsLayer = YES;
+  badge.layer.backgroundColor =
+      [[NSColor inspectorLabel] colorWithAlphaComponent:0.15].CGColor;
+  [badge setContentHuggingPriority:NSLayoutPriorityRequired
+                    forOrientation:NSLayoutConstraintOrientationHorizontal];
+  [badge setContentCompressionResistancePriority:NSLayoutPriorityRequired
+                                  forOrientation:
+                                      NSLayoutConstraintOrientationHorizontal];
+
+  NSTextField *label = [NSTextField
+      labelWithString:KKLoc(@"Default",
+                            @"Badge on a built-in (shipped) preset.")];
+  label.font = [NSFont systemFontOfSize:9.0 weight:NSFontWeightMedium];
+  label.textColor = badgeColor;
+  label.translatesAutoresizingMaskIntoConstraints = NO;
+  [badge addSubview:label];
+  [NSLayoutConstraint activateConstraints:@[
+    [label.leadingAnchor constraintEqualToAnchor:badge.leadingAnchor
+                                        constant:KKPaddingSM + 1.0],
+    [label.trailingAnchor constraintEqualToAnchor:badge.trailingAnchor
+                                         constant:-(KKPaddingSM + 1.0)],
+    [label.topAnchor constraintEqualToAnchor:badge.topAnchor
+                                    constant:KKPaddingXS],
+    [label.bottomAnchor constraintEqualToAnchor:badge.bottomAnchor
+                                       constant:-KKPaddingXS],
+  ]];
+  return badge;
+}
+
+- (void)_renameTapped:(id)sender {
+  _nameField.editable = YES;
+  _nameField.selectable = YES;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self.window makeKeyAndOrderFront:nil];
+    [self.window makeFirstResponder:self->_nameField];
+    self->_nameField.currentEditor.selectedRange =
+        NSMakeRange(0, self->_nameField.stringValue.length);
+  });
+}
+
+- (void)_applyAtTapped:(id)sender {
+  if (_onApply)
+    _onApply(_preset, YES);
+}
+
+- (void)_overwriteTapped:(id)sender {
+  if (_onOverwrite)
+    _onOverwrite(_preset.identifier);
+}
+
+- (void)_deleteTapped:(id)sender {
+  if (_onDelete)
+    _onDelete(_preset.identifier);
+}
+
+- (void)mouseDown:(NSEvent *)event {
+  // While inline-renaming, a click anywhere else just commits the edit.
+  if (_nameField.editable) {
+    [self.window makeFirstResponder:nil];
+    return;
+  }
+  // Clicking the row body applies as an override (the playhead button merges).
+  if (_onApply)
+    _onApply(_preset, NO);
+}
+
+- (void)updateTrackingAreas {
+  [super updateTrackingAreas];
+  for (NSTrackingArea *ta in [self.trackingAreas copy])
+    [self removeTrackingArea:ta];
+  NSTrackingArea *ta = [[NSTrackingArea alloc]
+      initWithRect:NSZeroRect
+           options:(NSTrackingMouseEnteredAndExited | NSTrackingCursorUpdate |
+                    NSTrackingActiveInKeyWindow | NSTrackingInVisibleRect)
+             owner:self
+          userInfo:nil];
+  [self addTrackingArea:ta];
+}
+
+- (void)mouseEntered:(NSEvent *)event {
+  self.layer.backgroundColor =
+      [[NSColor inspectorLabel] colorWithAlphaComponent:0.08].CGColor;
+}
+
+- (void)mouseExited:(NSEvent *)event {
+  self.layer.backgroundColor = NSColor.clearColor.CGColor;
+}
+
+- (void)cursorUpdate:(NSEvent *)event {
+  [[NSCursor pointingHandCursor] set];
+}
+
+- (void)controlTextDidEndEditing:(NSNotification *)notification {
+  _nameField.editable = NO;
+  _nameField.selectable = NO;
+  NSString *newName = [_nameField.stringValue
+      stringByTrimmingCharactersInSet:[NSCharacterSet
+                                          whitespaceAndNewlineCharacterSet]];
+  if (newName.length > 0 && ![newName isEqualToString:_preset.displayName] &&
+      _onRename)
+    _onRename(_preset.identifier, newName);
+}
+
+- (BOOL)control:(NSControl *)control
+               textView:(NSTextView *)textView
+    doCommandBySelector:(SEL)commandSelector {
+  if (commandSelector == @selector(insertNewline:)) {
+    [self.window makeFirstResponder:nil];
+    return YES;
+  }
+  if (commandSelector == @selector(cancelOperation:)) {
+    _nameField.stringValue = _preset.displayName;
+    _nameField.editable = NO;
+    _nameField.selectable = NO;
+    [self.window makeFirstResponder:nil];
+    return YES;
+  }
+  return NO;
+}
+
+@end

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetRowView.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetRowView.m
@@ -14,6 +14,13 @@
 const CGFloat KKPresetPopoverWidth = 280.0;
 const CGFloat KKPresetRowHeight = 28.0;
 
+NSRect KKPresetScreenRectForView(NSView *v) {
+  NSWindow *w = v.window;
+  if (!v || !w)
+    return NSZeroRect;
+  return [w convertRectToScreen:[v convertRect:v.bounds toView:nil]];
+}
+
 @implementation KKPresetsFlippedView
 - (BOOL)isFlipped {
   return YES;
@@ -309,6 +316,10 @@ const CGFloat KKPresetRowHeight = 28.0;
 
 - (void)cursorUpdate:(NSEvent *)event {
   [[NSCursor pointingHandCursor] set];
+}
+
+- (NSRect)insertButtonScreenRect {
+  return KKPresetScreenRectForView(_applyAtButton);
 }
 
 - (void)controlTextDidEndEditing:(NSNotification *)notification {

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetsPopover.h
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetsPopover.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+#pragma once
+
+#import <AppKit/AppKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Transient popover listing a plugin's animation presets (built-ins first,
+/// badged "Default"; then user presets with rename / overwrite / delete) plus a
+/// "save current as" form. Self-contained: reads and mutates the shared
+/// `KKPresets` store directly and works in plugin timeline JSON strings, so it
+/// stays decoupled from `KKTimeline`. Modeled on `KKGradientFavoritesPopover`.
+@interface KKPresetsPopover : NSObject
+
+/// Namespace the listed/saved presets belong to (the plugin's bundle id).
+@property(nonatomic, copy, nullable) NSString *pluginKey;
+
+/// Returns the current timeline JSON to capture on save / overwrite. Returning
+/// nil or empty cancels the operation.
+@property(nonatomic, copy, nullable) NSString *_Nullable (^currentTimelineJSON)
+    (void);
+
+/// The user picked a preset to apply; hand back its stored timeline JSON.
+/// `atPlayhead` NO = override the whole timeline; YES = merge the preset's
+/// animation in starting at the current playhead, keeping existing keyposes.
+@property(nonatomic, copy, nullable) void (^onApplyPreset)
+    (NSString *timelineJSON, BOOL atPlayhead);
+
+- (void)showRelativeToRect:(NSRect)rect ofView:(NSView *)view;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetsPopover.h
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetsPopover.h
@@ -32,6 +32,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)showRelativeToRect:(NSRect)rect ofView:(NSView *)view;
 
+#pragma mark - Guide support
+
+/// When YES the popover stays open (ApplicationDefined behavior) and applying a
+/// preset does NOT auto-close it, so a walkthrough can drive apply / insert /
+/// save in one open popover. The guide owns closing it.
+@property(nonatomic) BOOL guideMode;
+/// Fired right after the popover is shown (guide's open step advances on it).
+@property(nonatomic, copy, nullable) void (^onDidShow)(void);
+/// Fired after any preset is applied (guide advances on it).
+@property(nonatomic, copy, nullable) void (^onDidApplyPreset)(void);
+/// Fired after a preset is saved, with its new identifier (guide captures it
+/// to delete on completion, and advances).
+@property(nonatomic, copy, nullable) void (^onDidSavePreset)
+    (NSString *identifier);
+/// The popover's window, for the guide's `additionalPassthroughWindow`.
+@property(nonatomic, readonly, nullable) NSWindow *popoverWindow;
+- (NSRect)guidePopoverScreenRect; // the whole popover content
+- (NSRect)guideFirstRowScreenRect;
+- (NSRect)guideFirstRowInsertButtonScreenRect;
+- (NSRect)guideSaveAreaScreenRect; // field + save button unioned
+/// Pre-fill the name/filter field (so a guide's save step is a single click).
+- (void)guidePrefillName:(NSString *)name;
+- (void)closeForGuide;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetsPopover.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetsPopover.m
@@ -1,0 +1,349 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+#import "KKPresetsPopover.h"
+
+#import "KKLocalized.h"
+#import "KKPopoverHeaderView.h"
+#import "KKPresetRowView.h"
+#import "KKPresets.h"
+#import <KeyframelessKit/KKTokens.h>
+#import <KeyframelessKit/NSColor+KKColors.h>
+
+static const CGFloat kSaveRowHeight = 32.0;
+static const CGFloat kEmptyRowHeight = 28.0;
+static const CGFloat kMaxVisibleRows = 7;
+
+// Same macOS 26 liquid-glass double-border fix the gradient/curve popovers use.
+static void _clearPopoverBackground(NSView *view) {
+  dispatch_after(
+      dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)),
+      dispatch_get_main_queue(), ^{
+        NSView *current = view;
+        NSView *popoverFrame = nil;
+        while (current) {
+          if ([NSStringFromClass([current class])
+                  hasPrefix:@"NSPopoverFrame"]) {
+            popoverFrame = current;
+            break;
+          }
+          current = current.superview;
+        }
+        if (!popoverFrame)
+          return;
+        for (NSView *sub in popoverFrame.subviews) {
+          if (![NSStringFromClass([sub class]) containsString:@"GlassView"])
+            continue;
+          for (NSView *glassSub in sub.subviews) {
+            glassSub.wantsLayer = YES;
+            NSString *name = NSStringFromClass([glassSub class]);
+            if ([name containsString:@"CoreHostingView"])
+              glassSub.layer.opacity = 0;
+            else if ([name containsString:@"ContentHolderView"])
+              glassSub.layer.backgroundColor = NSColor.clearColor.CGColor;
+          }
+          break;
+        }
+      });
+}
+
+@interface KKPresetsContentView : NSView
+@end
+
+@implementation KKPresetsContentView
+
+- (BOOL)isFlipped {
+  return YES;
+}
+
+- (void)viewDidMoveToWindow {
+  [super viewDidMoveToWindow];
+  if (self.window)
+    _clearPopoverBackground(self);
+}
+
+@end
+
+@interface KKPresetsPopover () <NSTextFieldDelegate, NSPopoverDelegate>
+@end
+
+@implementation KKPresetsPopover {
+  NSPopover *_popover;
+  KKPresetsContentView *_contentView;
+  KKPopoverHeaderView *_header;
+  NSScrollView *_listScroll;
+  KKPresetsFlippedView *_listContainer;
+  NSBox *_separator;
+  NSView *_saveRow;
+  NSTextField *_emptyLabel;
+  KKPresetNameTextField *_filterField;
+  __weak NSView *_anchorView;
+  NSRect _anchorRect;
+}
+
+- (void)showRelativeToRect:(NSRect)rect ofView:(NSView *)view {
+  if (_popover.isShown) {
+    [_popover close];
+    return;
+  }
+  _anchorView = view;
+  _anchorRect = rect;
+
+  [self _buildChrome];
+  [self _reloadList];
+
+  NSViewController *vc = [[NSViewController alloc] init];
+  vc.view = _contentView;
+
+  _popover = [[NSPopover alloc] init];
+  _popover.contentViewController = vc;
+  _popover.behavior = NSPopoverBehaviorTransient;
+  _popover.delegate = self;
+  _popover.contentSize = _contentView.frame.size;
+  [_popover showRelativeToRect:rect ofView:view preferredEdge:NSRectEdgeMinY];
+}
+
+// Persistent chrome built once: a scrollable list region, a separator, and the
+// combined filter/name field + save button. `_reloadList` fills and sizes it in
+// place so typing-to-filter keeps the field focused (no close/reopen).
+- (void)_buildChrome {
+  _contentView = [[KKPresetsContentView alloc]
+      initWithFrame:NSMakeRect(0, 0, KKPresetPopoverWidth, kSaveRowHeight)];
+
+  // Title row matches the motion-blur / constants popovers (dimmed icon+title).
+  _header = [[KKPopoverHeaderView alloc]
+      initWithTitle:KKLoc(@"Presets",
+                          @"Section title: saved animation presets.")
+         symbolName:@"bookmark"];
+  _header.translatesAutoresizingMaskIntoConstraints = YES;
+  [_contentView addSubview:_header];
+
+  _listContainer = [[KKPresetsFlippedView alloc]
+      initWithFrame:NSMakeRect(0, 0, KKPresetPopoverWidth, KKPresetRowHeight)];
+  _listContainer.autoresizesSubviews = NO;
+
+  _listScroll = [[NSScrollView alloc]
+      initWithFrame:NSMakeRect(0, 0, KKPresetPopoverWidth, KKPresetRowHeight)];
+  _listScroll.documentView = _listContainer;
+  _listScroll.hasVerticalScroller = YES;
+  _listScroll.autohidesScrollers = YES;
+  _listScroll.drawsBackground = NO;
+  _listScroll.autoresizingMask = NSViewWidthSizable;
+  [_contentView addSubview:_listScroll];
+
+  _emptyLabel = [NSTextField labelWithString:@""];
+  _emptyLabel.font = [NSFont systemFontOfSize:11.0];
+  _emptyLabel.textColor = [NSColor.inspectorLabel colorWithAlphaComponent:0.4];
+  _emptyLabel.alignment = NSTextAlignmentCenter;
+  _emptyLabel.autoresizingMask = NSViewWidthSizable;
+  _emptyLabel.hidden = YES;
+  [_contentView addSubview:_emptyLabel];
+
+  _separator = [[NSBox alloc] initWithFrame:NSZeroRect];
+  _separator.boxType = NSBoxSeparator;
+  [_contentView addSubview:_separator];
+
+  _saveRow = [[NSView alloc]
+      initWithFrame:NSMakeRect(0, 0, KKPresetPopoverWidth, kSaveRowHeight)];
+  _saveRow.autoresizingMask = NSViewWidthSizable;
+
+  _filterField = [[KKPresetNameTextField alloc] initWithFrame:NSZeroRect];
+  _filterField.placeholderString =
+      KKLoc(@"Filter or name",
+            @"Placeholder: type to filter the preset list, or to name a new "
+            @"preset.");
+  _filterField.font = [NSFont systemFontOfSize:11.0];
+  _filterField.textColor = [NSColor inspectorLabel];
+  _filterField.bezeled = YES;
+  _filterField.bezelStyle = NSTextFieldRoundedBezel;
+  _filterField.focusRingType = NSFocusRingTypeNone;
+  _filterField.translatesAutoresizingMaskIntoConstraints = NO;
+  _filterField.delegate = self;
+  [_saveRow addSubview:_filterField];
+
+  NSImageSymbolConfiguration *cfg = [NSImageSymbolConfiguration
+      configurationWithPointSize:11.0
+                          weight:NSFontWeightMedium];
+  NSImage *plusImg = [[NSImage
+      imageWithSystemSymbolName:@"plus"
+       accessibilityDescription:KKLoc(@"Save preset",
+                                      @"Accessibility: save the current "
+                                      @"animation as a preset.")]
+      imageWithSymbolConfiguration:cfg];
+  NSButton *saveBtn = [NSButton buttonWithImage:plusImg
+                                         target:self
+                                         action:@selector(_saveTapped:)];
+  saveBtn.bordered = NO;
+  saveBtn.contentTintColor = [NSColor inspectorLabel];
+  saveBtn.toolTip =
+      KKLoc(@"Save preset", @"Accessibility: save the current animation as a "
+                            @"preset.");
+  saveBtn.translatesAutoresizingMaskIntoConstraints = NO;
+  [_saveRow addSubview:saveBtn];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [_filterField.leadingAnchor constraintEqualToAnchor:_saveRow.leadingAnchor
+                                               constant:KKPaddingLG],
+    [_filterField.centerYAnchor constraintEqualToAnchor:_saveRow.centerYAnchor],
+    [_filterField.trailingAnchor constraintEqualToAnchor:saveBtn.leadingAnchor
+                                                constant:-KKSpacingSM],
+    [saveBtn.trailingAnchor constraintEqualToAnchor:_saveRow.trailingAnchor
+                                           constant:-KKPaddingLG],
+    [saveBtn.centerYAnchor constraintEqualToAnchor:_saveRow.centerYAnchor],
+    [saveBtn.widthAnchor constraintEqualToConstant:20.0],
+    [saveBtn.heightAnchor constraintEqualToConstant:20.0],
+  ]];
+  [_contentView addSubview:_saveRow];
+}
+
+- (NSString *)_filterText {
+  return [_filterField.stringValue
+      stringByTrimmingCharactersInSet:[NSCharacterSet
+                                          whitespaceAndNewlineCharacterSet]];
+}
+
+- (NSArray<KKPreset *> *)_filteredPresets {
+  NSArray<KKPreset *> *all =
+      [[KKPresets shared] presetsForPluginKey:(_pluginKey ?: @"")];
+  NSString *q = [self _filterText];
+  if (q.length == 0)
+    return all;
+  NSMutableArray<KKPreset *> *out = [NSMutableArray new];
+  for (KKPreset *p in all)
+    if ([p.displayName rangeOfString:q options:NSCaseInsensitiveSearch]
+            .location != NSNotFound)
+      [out addObject:p];
+  return out;
+}
+
+// Rebuild the list rows in place and resize the popover - never close/reopen,
+// so the filter field keeps focus while typing.
+- (void)_reloadList {
+  NSArray<KKPreset *> *presets = [self _filteredPresets];
+  for (NSView *v in [_listContainer.subviews copy])
+    [v removeFromSuperview];
+
+  __weak typeof(self) weakSelf = self;
+  CGFloat rowY = 0;
+  for (KKPreset *preset in presets) {
+    KKPresetRowView *row = [[KKPresetRowView alloc] initWithPreset:preset];
+    row.frame = NSMakeRect(0, rowY, KKPresetPopoverWidth, KKPresetRowHeight);
+    row.autoresizingMask = NSViewWidthSizable;
+    row.onApply = ^(KKPreset *p, BOOL atPlayhead) {
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      if (!strongSelf)
+        return;
+      // Defer the close: closing an NSPopover from inside its own click handler
+      // in an XPC view service crashes via ViewBridge re-entrancy.
+      if (strongSelf.onApplyPreset && p.timelineJSON.length)
+        strongSelf.onApplyPreset(p.timelineJSON, atPlayhead);
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (strongSelf->_popover)
+          [strongSelf->_popover close];
+      });
+    };
+    row.onDelete = ^(NSString *identifier) {
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      if (!strongSelf)
+        return;
+      [[KKPresets shared] removePresetWithIdentifier:identifier];
+      [strongSelf _reloadList];
+    };
+    row.onOverwrite = ^(NSString *identifier) {
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      if (!strongSelf)
+        return;
+      NSString *json = strongSelf.currentTimelineJSON
+                           ? strongSelf.currentTimelineJSON()
+                           : nil;
+      if (!json.length)
+        return;
+      [[KKPresets shared] updatePresetWithIdentifier:identifier
+                                        timelineJSON:json];
+      [strongSelf _reloadList];
+    };
+    row.onRename = ^(NSString *identifier, NSString *newName) {
+      [[KKPresets shared] renamePresetWithIdentifier:identifier toName:newName];
+    };
+    [_listContainer addSubview:row];
+    rowY += KKPresetRowHeight;
+  }
+
+  CGFloat listHeight = presets.count * KKPresetRowHeight;
+  CGFloat clipped = fmin(listHeight, kMaxVisibleRows * KKPresetRowHeight);
+  BOOL hasItems = presets.count > 0;
+  CGFloat listRegion = hasItems ? clipped : kEmptyRowHeight;
+
+  CGFloat headerH = [KKPopoverHeaderView height];
+  _header.frame = NSMakeRect(KKPaddingMD, KKPaddingMD,
+                             KKPresetPopoverWidth - KKPaddingMD * 2, headerH);
+  CGFloat listTop = KKPaddingMD + headerH + KKSpacingSM;
+
+  _listContainer.frame =
+      NSMakeRect(0, 0, KKPresetPopoverWidth, fmax(listHeight, 1.0));
+  _listScroll.frame = NSMakeRect(0, listTop, KKPresetPopoverWidth, listRegion);
+  _listScroll.hidden = !hasItems;
+
+  _emptyLabel.hidden = hasItems;
+  if (!hasItems) {
+    _emptyLabel.stringValue =
+        [self _filterText].length > 0
+            ? KKLoc(@"No matches",
+                    @"Empty state when a preset filter matches nothing.")
+            : KKLoc(@"No presets saved", @"Empty state for the preset list.");
+    _emptyLabel.frame = NSMakeRect(0, listTop + (kEmptyRowHeight - 16.0) / 2.0,
+                                   KKPresetPopoverWidth, 16.0);
+  }
+
+  CGFloat y = listTop + listRegion;
+  _separator.frame =
+      NSMakeRect(KKPaddingLG, y, KKPresetPopoverWidth - KKPaddingLG * 2, 1);
+  y += KKSpacingSM;
+  _saveRow.frame = NSMakeRect(0, y, KKPresetPopoverWidth, kSaveRowHeight);
+  y += kSaveRowHeight;
+
+  // Before the popover exists, size the content view so showRelativeToRect can
+  // read it. Once shown, the popover OWNS the content view's frame - setting it
+  // ourselves fights the popover and shifts the content on every keystroke;
+  // just drive the size through contentSize.
+  if (_popover.isShown)
+    _popover.contentSize = NSMakeSize(KKPresetPopoverWidth, y);
+  else
+    _contentView.frame = NSMakeRect(0, 0, KKPresetPopoverWidth, y);
+}
+
+- (BOOL)control:(NSControl *)control
+               textView:(NSTextView *)textView
+    doCommandBySelector:(SEL)commandSelector {
+  if (control == _filterField && commandSelector == @selector(insertNewline:)) {
+    [self _saveTapped:nil];
+    return YES;
+  }
+  return NO;
+}
+
+- (void)controlTextDidChange:(NSNotification *)note {
+  if (note.object == _filterField)
+    [self _reloadList];
+}
+
+- (void)_saveTapped:(id)sender {
+  NSString *name = [self _filterText];
+  if (name.length == 0)
+    return;
+  NSString *json = _currentTimelineJSON ? _currentTimelineJSON() : nil;
+  if (!json.length)
+    return;
+  [[KKPresets shared] addPresetWithName:name
+                              pluginKey:(_pluginKey ?: @"")timelineJSON:json];
+  _filterField.stringValue = @"";
+  [self _reloadList];
+}
+
+- (void)popoverDidClose:(NSNotification *)notification {
+  _popover = nil;
+}
+
+@end

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetsPopover.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKPresetsPopover.m
@@ -77,6 +77,7 @@ static void _clearPopoverBackground(NSView *view) {
   KKPresetsFlippedView *_listContainer;
   NSBox *_separator;
   NSView *_saveRow;
+  NSButton *_saveButton;
   NSTextField *_emptyLabel;
   KKPresetNameTextField *_filterField;
   __weak NSView *_anchorView;
@@ -99,10 +100,24 @@ static void _clearPopoverBackground(NSView *view) {
 
   _popover = [[NSPopover alloc] init];
   _popover.contentViewController = vc;
-  _popover.behavior = NSPopoverBehaviorTransient;
+  // ApplicationDefined during a guide so the overlay/host clicks don't dismiss
+  // it; Transient otherwise.
+  _popover.behavior = _guideMode ? NSPopoverBehaviorApplicationDefined
+                                 : NSPopoverBehaviorTransient;
   _popover.delegate = self;
   _popover.contentSize = _contentView.frame.size;
   [_popover showRelativeToRect:rect ofView:view preferredEdge:NSRectEdgeMinY];
+  // A guide drives the popover with narrated steps; the filter field auto-
+  // focuses on open, so clear it (next tick, after the popover sets its initial
+  // responder) to keep keystrokes out of it during the walkthrough.
+  if (_guideMode) {
+    __weak typeof(self) weak = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [weak.popoverWindow makeFirstResponder:nil];
+    });
+  }
+  if (self.onDidShow)
+    self.onDidShow();
 }
 
 // Persistent chrome built once: a scrollable list region, a separator, and the
@@ -181,6 +196,7 @@ static void _clearPopoverBackground(NSView *view) {
       KKLoc(@"Save preset", @"Accessibility: save the current animation as a "
                             @"preset.");
   saveBtn.translatesAutoresizingMaskIntoConstraints = NO;
+  _saveButton = saveBtn;
   [_saveRow addSubview:saveBtn];
 
   [NSLayoutConstraint activateConstraints:@[
@@ -239,6 +255,12 @@ static void _clearPopoverBackground(NSView *view) {
       // in an XPC view service crashes via ViewBridge re-entrancy.
       if (strongSelf.onApplyPreset && p.timelineJSON.length)
         strongSelf.onApplyPreset(p.timelineJSON, atPlayhead);
+      if (strongSelf.onDidApplyPreset)
+        strongSelf.onDidApplyPreset();
+      // A guide keeps the popover open to chain apply -> insert -> save; it
+      // closes it itself on completion.
+      if (strongSelf.guideMode)
+        return;
       dispatch_async(dispatch_get_main_queue(), ^{
         if (strongSelf->_popover)
           [strongSelf->_popover close];
@@ -336,14 +358,61 @@ static void _clearPopoverBackground(NSView *view) {
   NSString *json = _currentTimelineJSON ? _currentTimelineJSON() : nil;
   if (!json.length)
     return;
-  [[KKPresets shared] addPresetWithName:name
-                              pluginKey:(_pluginKey ?: @"")timelineJSON:json];
+  KKPreset *saved = [[KKPresets shared]
+      addPresetWithName:name
+              pluginKey:(_pluginKey ?: @"")timelineJSON:json];
   _filterField.stringValue = @"";
   [self _reloadList];
+  if (self.onDidSavePreset && saved.identifier)
+    self.onDidSavePreset(saved.identifier);
 }
 
 - (void)popoverDidClose:(NSNotification *)notification {
   _popover = nil;
+}
+
+#pragma mark - Guide support
+
+- (NSWindow *)popoverWindow {
+  return _contentView.window;
+}
+
+- (KKPresetRowView *)_firstRow {
+  for (NSView *v in _listContainer.subviews)
+    if ([v isKindOfClass:[KKPresetRowView class]])
+      return (KKPresetRowView *)v;
+  return nil;
+}
+
+- (NSRect)guidePopoverScreenRect {
+  return KKPresetScreenRectForView(_contentView);
+}
+
+- (NSRect)guideFirstRowScreenRect {
+  return KKPresetScreenRectForView([self _firstRow]);
+}
+
+- (NSRect)guideFirstRowInsertButtonScreenRect {
+  return [[self _firstRow] insertButtonScreenRect];
+}
+
+- (NSRect)guideSaveAreaScreenRect {
+  NSRect f = KKPresetScreenRectForView(_filterField);
+  NSRect b = KKPresetScreenRectForView(_saveButton);
+  if (NSIsEmptyRect(f))
+    return b;
+  if (NSIsEmptyRect(b))
+    return f;
+  return NSUnionRect(f, b);
+}
+
+- (void)guidePrefillName:(NSString *)name {
+  _filterField.stringValue = name ?: @"";
+  [self _reloadList];
+}
+
+- (void)closeForGuide {
+  [_popover close];
 }
 
 @end

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+ParameterRows.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+ParameterRows.m
@@ -527,7 +527,7 @@
         [row.heightAnchor
             constraintEqualToConstant:bottomRowHeights[i].doubleValue],
         [above.bottomAnchor constraintEqualToAnchor:row.topAnchor
-                                           constant:-KKPaddingMD],
+                                           constant:-KKPaddingXS],
       ]];
       above = row;
     }

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+ParameterRows.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+ParameterRows.m
@@ -508,6 +508,10 @@
     [bottomRows addObject:_paramOrderRow];
     [bottomRowHeights addObject:@(kParamOrderRowHeight)];
   }
+  if (_showsPresetsRow && _presetsRow) {
+    [bottomRows addObject:_presetsRow];
+    [bottomRowHeights addObject:@(kPresetsRowHeight)];
+  }
 
   if (bottomRows.count == 0) {
     [box.bottomAnchor constraintEqualToAnchor:self.bottomAnchor

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+Presets.h
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+Presets.h
@@ -15,6 +15,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface KKTimelineInspectorView (Presets)
 /// Last reachable clip fraction (the playhead stops one frame before clip end).
 - (double)_presetEndFraction;
+/// Runs the shared Presets walkthrough: opens the Presets popover and guides
+/// the user through applying a preset, the apply-at-playhead button, and saving
+/// one. The host snapshots + restores the pre-guide timeline; the practice
+/// preset the user saves is removed on completion.
+- (void)runPresetsGuide;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+Presets.h
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+Presets.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+#pragma once
+
+#import "KKTimelineInspectorView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// The Presets row + popover wiring. Pure timeline transforms live in
+/// KKPresetTimelineOps; this category owns the row, the popover lifecycle, and
+/// the apply/save plumbing into the inspector.
+@interface KKTimelineInspectorView (Presets)
+/// Last reachable clip fraction (the playhead stops one frame before clip end).
+- (double)_presetEndFraction;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+Presets.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+Presets.m
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+#import "KKTimelineInspectorView+Presets.h"
+#import "KKTimelineInspectorView_Private.h"
+
+#import "KKLocalized.h"
+#import "KKPresetTimelineOps.h"
+#import "KKPresetsPopover.h"
+#import <KeyframelessKit/KKTimingCompat.h>
+
+@interface KKTimelineInspectorView (PresetsInternal)
+- (void)_applyPresetJSON:(NSString *)timelineJSON atPlayhead:(BOOL)atPlayhead;
+@end
+
+@implementation KKTimelineInspectorView (Presets)
+
+// Falls back to 1.0 until the clip/frame duration is known.
+- (double)_presetEndFraction {
+  if (_clipDurationSeconds > 0.0 && _frameDurationSeconds > 0.0 &&
+      _frameDurationSeconds < _clipDurationSeconds)
+    return (_clipDurationSeconds - _frameDurationSeconds) /
+           _clipDurationSeconds;
+  return 1.0;
+}
+
+- (void)_buildPresetsRow {
+  KKCheckboxView *unused = nil;
+  _presetsRow = [self
+      _buildTickGearRowWithParameterID:0
+                            iconSymbol:@"bookmark"
+                                 title:KKLoc(@"Presets",
+                                             @"Section title: saved animation "
+                                             @"presets.")
+                     gearAccessibility:KKLoc(@"Preset library",
+                                             @"Accessibility: open the saved "
+                                             @"animation preset library.")
+                            gearAction:@selector(_presetsClicked:)
+                          showCheckbox:NO
+                              checkbox:&unused
+                            gearButton:&_presetsButton];
+  [self addSubview:_presetsRow];
+}
+
+- (void)_presetsClicked:(id)sender {
+  KKPresetsPopover *popover = _presetsPopover;
+  if (!popover) {
+    popover = [[KKPresetsPopover alloc] init];
+    _presetsPopover = popover;
+    __weak typeof(self) weak = self;
+    popover.currentTimelineJSON = ^NSString *_Nullable {
+      KKTimelineInspectorView *strong = weak;
+      KKTimeline *timeline = strong.basicLanesView.currentTimeline;
+      if (!timeline)
+        return nil;
+      // Fix the moving gaps to seconds so the preset keeps its transition feel.
+      timeline =
+          KKPresetTimelineAutoLocked(timeline, strong->_clipDurationSeconds);
+      return [KKTimeline jsonFromTimeline:timeline];
+    };
+    popover.onApplyPreset = ^(NSString *timelineJSON, BOOL atPlayhead) {
+      KKTimelineInspectorView *strong = weak;
+      if (!strong)
+        return;
+      [strong _applyPresetJSON:timelineJSON atPlayhead:atPlayhead];
+    };
+  }
+  popover.pluginKey = self.presetPluginKey;
+  [popover showRelativeToRect:_presetsButton.bounds ofView:_presetsButton];
+}
+
+- (void)_applyPresetJSON:(NSString *)timelineJSON atPlayhead:(BOOL)atPlayhead {
+  KKTimeline *preset = [KKTimeline timelineFromJSON:timelineJSON];
+  if (!preset)
+    return;
+  double end = [self _presetEndFraction];
+  double clip = _clipDurationSeconds;
+  KKTimeline *result;
+  if (atPlayhead) {
+    // Merge the preset in starting at the playhead, keeping earlier keyposes -
+    // lets you stack e.g. a pop-in then a later pop-out.
+    double p = self.basicLanesView.playheadFraction;
+    p = fmax(0.0, fmin(p, end));
+    result = KKPresetTimelineMergedAtFraction(
+        preset, self.basicLanesView.currentTimeline, p, end, clip);
+  } else {
+    // Override: fit the preset to the clip's reachable range [0, end].
+    result = KKPresetTimelineRemapped(preset, 0.0, end, clip);
+  }
+  if (!result)
+    return;
+  // Persist + undo via the host's existing write path, then refresh the UI
+  // immediately (the same two-step the AI merge apply uses).
+  if (self.onTimelineMutated)
+    self.onTimelineMutated(result);
+  [self applyTimeline:result];
+  // A multi-lane / structurally-rich preset may not fit Basic; jump to Advanced
+  // so the user sees the real animation rather than a degraded Basic
+  // projection.
+  if (_selectedTab == KKTimelineTabBasic &&
+      !KKTimelineIsBasicCompatible(result, end))
+    [self setActiveTab:KKTimelineTabAdvanced];
+}
+
+@end

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+Presets.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView+Presets.m
@@ -3,12 +3,19 @@
  * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
  */
 
+#import "KKTimelineInspectorView+Guide.h"
 #import "KKTimelineInspectorView+Presets.h"
 #import "KKTimelineInspectorView_Private.h"
 
+#import "KKCheckboxView.h"
 #import "KKLocalized.h"
+#import "KKParameterRowView.h"
+#import "KKPresetRowView.h" // KKPresetScreenRectForView
 #import "KKPresetTimelineOps.h"
+#import "KKPresets.h"
 #import "KKPresetsPopover.h"
+#import <KeyframelessKit/KKJoyrideController.h>
+#import <KeyframelessKit/KKJoyrideGuideHost.h>
 #import <KeyframelessKit/KKTimingCompat.h>
 
 @interface KKTimelineInspectorView (PresetsInternal)
@@ -44,7 +51,8 @@
   [self addSubview:_presetsRow];
 }
 
-- (void)_presetsClicked:(id)sender {
+// Lazily build the popover and wire its save-capture + apply callbacks once.
+- (KKPresetsPopover *)_ensurePresetsPopover {
   KKPresetsPopover *popover = _presetsPopover;
   if (!popover) {
     popover = [[KKPresetsPopover alloc] init];
@@ -68,7 +76,12 @@
     };
   }
   popover.pluginKey = self.presetPluginKey;
-  [popover showRelativeToRect:_presetsButton.bounds ofView:_presetsButton];
+  return popover;
+}
+
+- (void)_presetsClicked:(id)sender {
+  [[self _ensurePresetsPopover] showRelativeToRect:_presetsButton.bounds
+                                            ofView:_presetsButton];
 }
 
 - (void)_applyPresetJSON:(NSString *)timelineJSON atPlayhead:(BOOL)atPlayhead {
@@ -102,6 +115,147 @@
   if (_selectedTab == KKTimelineTabBasic &&
       !KKTimelineIsBasicCompatible(result, end))
     [self setActiveTab:KKTimelineTabAdvanced];
+}
+
+#pragma mark - Guide
+
+- (NSArray<KKJoyrideStep *> *)
+    _presetsGuideStepsForGuide:(KKJoyrideController *)guide
+                       popover:(KKPresetsPopover *)pop {
+  __weak KKPresetsPopover *wpop = pop;
+  __weak KKJoyrideController *wguide = guide;
+  __weak typeof(self) wself = self;
+  // Cutout clicks reach the popover only while its window is the controller's
+  // additionalPassthroughWindow - so only the (interactive) apply step sets it;
+  // the narrated steps clear it so their spotlighted buttons aren't pressable.
+  // Resolved lazily because the popover isn't open until the user opens it.
+  void (^passthrough)(BOOL) = ^(BOOL on) {
+    wguide.additionalPassthroughWindow = on ? wpop.popoverWindow : nil;
+  };
+
+  // Step 1: the user opens the popover themselves (the gear lives in the host
+  // window, so the cutout click forwards there). Advances on onDidShow.
+  KKJoyrideStep *open = [KKJoyrideStep
+      stepWithMessage:KKLoc(@"Open your presets to get started.",
+                            @"Presets guide step: open the popover.")
+           targetView:nil];
+  open.targetScreenRect = ^{
+    __strong typeof(wself) s = wself;
+    return s ? KKPresetScreenRectForView(s->_presetsButton) : NSZeroRect;
+  };
+  open.onEnter = ^{
+    passthrough(NO);
+  };
+
+  KKJoyrideStep *apply = [KKJoyrideStep
+      stepWithMessage:KKLoc(@"Click a preset to apply it - it replaces the "
+                            @"current animation.",
+                            @"Presets guide step: apply.")
+           targetView:nil];
+  apply.targetScreenRect = ^{
+    return wpop ? [wpop guideFirstRowScreenRect] : NSZeroRect;
+  };
+  apply.onEnter = ^{
+    passthrough(YES);
+  };
+
+  KKJoyrideStep *insert = [KKJoyrideStep
+      stepWithMessage:KKLoc(@"This inserts the preset at the playhead instead, "
+                            @"keeping your existing keyposes.",
+                            @"Presets guide step: insert at playhead.")
+           targetView:nil];
+  insert.targetScreenRect = ^{
+    return wpop ? [wpop guideFirstRowInsertButtonScreenRect] : NSZeroRect;
+  };
+  insert.showsNext = YES;
+  insert.onEnter = ^{
+    passthrough(NO);
+  };
+
+  KKJoyrideStep *save = [KKJoyrideStep
+      stepWithMessage:KKLoc(@"To save your own, type a name here and press +.",
+                            @"Presets guide step: save.")
+           targetView:nil];
+  save.targetScreenRect = ^{
+    return wpop ? [wpop guideSaveAreaScreenRect] : NSZeroRect;
+  };
+  save.showsNext = YES;
+  save.onEnter = ^{
+    passthrough(NO);
+  };
+
+  KKJoyrideStep *closer = [KKJoyrideStep
+      stepWithMessage:KKLoc(@"Presets let you reuse a move across clips and "
+                            @"projects - build it once, apply it anywhere.",
+                            @"Presets guide step: closing value statement.")
+           targetView:nil];
+  closer.targetScreenRect = ^{
+    return wpop ? [wpop guidePopoverScreenRect] : NSZeroRect;
+  };
+  closer.showsNext = YES;
+  closer.onEnter = ^{
+    passthrough(NO);
+  };
+
+  return @[ open, apply, insert, save, closer ];
+}
+
+- (void)runPresetsGuide {
+  KKJoyrideGuideHost *host = [self timingGuideHost];
+  // forwardsGestures + the apply step's additionalPassthroughWindow let that
+  // step's cutout click reach the popover.
+  host.forwardsGestures = YES;
+  __weak typeof(self) weak = self;
+
+  host.onRunWillStart = ^{
+    __strong typeof(weak) s = weak;
+    if (!s)
+      return;
+    // Prepare the popover but DON'T open it - the first step has the user open
+    // it. guideMode makes it stay open + not auto-close on apply once shown.
+    KKPresetsPopover *pop = [s _ensurePresetsPopover];
+    pop.guideMode = YES;
+  };
+
+  [host
+      runWithSeed:^KKTimeline * {
+        // Seed with the current timeline so the host snapshots and restores it
+        // (undoing the demo apply); nothing visibly changes at start.
+        __strong typeof(weak) s = weak;
+        return s.basicLanesView.currentTimeline;
+      }
+      buildSteps:^NSArray<KKJoyrideStep *> *(KKJoyrideController *guide,
+                                             KKJoyrideLanesBinder *binder) {
+        __strong typeof(weak) s = weak;
+        if (!s)
+          return @[];
+        KKPresetsPopover *pop = (KKPresetsPopover *)s->_presetsPopover;
+        pop.onDidShow = ^{
+          __strong typeof(weak) s2 = weak;
+          KKJoyrideController *g = [s2 timingGuideHost].currentGuide;
+          if (g.currentStepIndex == 0) // the open step
+            [g advance];
+        };
+        pop.onDidApplyPreset = ^{
+          __strong typeof(weak) s2 = weak;
+          KKJoyrideController *g = [s2 timingGuideHost].currentGuide;
+          if (g.currentStepIndex == 1) // the apply step
+            [g advance];
+        };
+        return [s _presetsGuideStepsForGuide:guide popover:pop];
+      }
+      extraOnComplete:^{
+        __strong typeof(weak) s = weak;
+        if (!s)
+          return;
+        KKPresetsPopover *pop = (KKPresetsPopover *)s->_presetsPopover;
+        pop.onDidShow = nil;
+        pop.onDidApplyPreset = nil;
+        [pop closeForGuide];
+        pop.guideMode = NO;
+        // Clear the open-popover hook so other guides don't reopen it.
+        [s timingGuideHost].onRunWillStart = nil;
+      }];
 }
 
 @end

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView.h
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView.h
@@ -51,6 +51,10 @@ typedef NS_ENUM(NSInteger, KKTimelineTab) {
 @property(nonatomic, copy, nullable) NSString *managePopoverSpotlightLabel;
 /// Title drawn on the Constants button. Default @"Constants".
 @property(nonatomic, copy) NSString *constantsButtonTitle;
+/// Namespace the Presets row reads/writes under (the plugin's bundle id). Set
+/// by the host during inspector wiring; nil disables built-ins lookup. Used
+/// only when `showsPresetsRow` is YES.
+@property(nonatomic, copy, nullable) NSString *presetPluginKey;
 
 #pragma mark - Callbacks (host wires playback / loop param / FxRemoteWindow)
 
@@ -191,6 +195,11 @@ typedef NS_ENUM(NSInteger, KKTimelineTab) {
 /// effect draws on-screen controls the user should be able to hide. Read once
 /// during init.
 - (BOOL)showsOSCVisibilityRow;
+
+/// Whether to build the "Presets" row below the box (and reserve height for
+/// it). Default YES - every timing plugin can save/load animation presets.
+/// Override to NO to opt out. Read once during init.
+- (BOOL)showsPresetsRow;
 
 @end
 

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView.m
@@ -32,14 +32,14 @@ static const CGFloat kInspectorHeight = 220.0;
 const CGFloat kHeaderRowHeight = 28.0;
 // The motion-blur parameter row sits in its own section below the box. The
 // custom-UI height is fixed at init, so we reserve this once up front.
-const CGFloat kMotionBlurRowHeight = 28.0;
+const CGFloat kMotionBlurRowHeight = 24.0;
 // The on-screen-control visibility row mirrors the motion-blur row's section
 // below the box; same fixed height reserved up front.
-const CGFloat kOSCVisibilityRowHeight = 28.0;
+const CGFloat kOSCVisibilityRowHeight = 24.0;
 // The property-order row mirrors the same section; gear-only (no checkbox).
-const CGFloat kParamOrderRowHeight = 28.0;
+const CGFloat kParamOrderRowHeight = 24.0;
 // The presets row mirrors the same section; gear-only (no checkbox).
-const CGFloat kPresetsRowHeight = 28.0;
+const CGFloat kPresetsRowHeight = 24.0;
 // Trailing margin that lands the checkbox on the native control gutter, same
 // value KKCustomGroupHeaderView uses.
 const CGFloat kMBCheckboxTrailing = 23.0;
@@ -327,11 +327,11 @@ const CGFloat kMBCheckboxTrailing = 23.0;
 
 - (CGFloat)_totalHeight {
   return kInspectorHeight +
-         (_showsMotionBlurRow ? kMotionBlurRowHeight + KKPaddingMD : 0.0) +
-         (_showsOSCVisibilityRow ? kOSCVisibilityRowHeight + KKPaddingMD
+         (_showsMotionBlurRow ? kMotionBlurRowHeight + KKPaddingXS : 0.0) +
+         (_showsOSCVisibilityRow ? kOSCVisibilityRowHeight + KKPaddingXS
                                  : 0.0) +
-         (_showsParamOrderRow ? kParamOrderRowHeight + KKPaddingMD : 0.0) +
-         (_showsPresetsRow ? kPresetsRowHeight + KKPaddingMD : 0.0);
+         (_showsParamOrderRow ? kParamOrderRowHeight + KKPaddingXS : 0.0) +
+         (_showsPresetsRow ? kPresetsRowHeight + KKPaddingXS : 0.0);
 }
 
 // Builds one of the optional rows below the box - a labeled left view plus a

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView.m
@@ -38,6 +38,8 @@ const CGFloat kMotionBlurRowHeight = 28.0;
 const CGFloat kOSCVisibilityRowHeight = 28.0;
 // The property-order row mirrors the same section; gear-only (no checkbox).
 const CGFloat kParamOrderRowHeight = 28.0;
+// The presets row mirrors the same section; gear-only (no checkbox).
+const CGFloat kPresetsRowHeight = 28.0;
 // Trailing margin that lands the checkbox on the native control gutter, same
 // value KKCustomGroupHeaderView uses.
 const CGFloat kMBCheckboxTrailing = 23.0;
@@ -73,6 +75,7 @@ const CGFloat kMBCheckboxTrailing = 23.0;
   _showsOSCVisibilityRow = [self showsOSCVisibilityRow];
   // Reordering is moot with 0/1 properties.
   _showsParamOrderRow = (_availableLanes.count >= 2);
+  _showsPresetsRow = [self showsPresetsRow];
   _mbShutterAngle = 180.0; // the natural shutter
   _mbSamples = 16;
   _mbMode = KKMotionBlurModeTransitionsOnly; // default; cheapest
@@ -91,6 +94,8 @@ const CGFloat kMBCheckboxTrailing = 23.0;
     [self _buildOSCVisibilityRow];
   if (_showsParamOrderRow)
     [self _buildParamOrderRow];
+  if (_showsPresetsRow)
+    [self _buildPresetsRow];
   [self _installConstraints:box headerRow:headerRow];
   return self;
 }
@@ -316,12 +321,17 @@ const CGFloat kMBCheckboxTrailing = 23.0;
   return NO;
 }
 
+- (BOOL)showsPresetsRow {
+  return YES;
+}
+
 - (CGFloat)_totalHeight {
   return kInspectorHeight +
          (_showsMotionBlurRow ? kMotionBlurRowHeight + KKPaddingMD : 0.0) +
          (_showsOSCVisibilityRow ? kOSCVisibilityRowHeight + KKPaddingMD
                                  : 0.0) +
-         (_showsParamOrderRow ? kParamOrderRowHeight + KKPaddingMD : 0.0);
+         (_showsParamOrderRow ? kParamOrderRowHeight + KKPaddingMD : 0.0) +
+         (_showsPresetsRow ? kPresetsRowHeight + KKPaddingMD : 0.0);
 }
 
 // Builds one of the optional rows below the box - a labeled left view plus a
@@ -523,6 +533,7 @@ const CGFloat kMBCheckboxTrailing = 23.0;
   copy.miniViewerDelegate = _miniViewerDelegate;
   copy.managePopoverSpotlightLabel = _managePopoverSpotlightLabel;
   copy.constantsButtonTitle = _constantsButtonTitle;
+  copy.presetPluginKey = self.presetPluginKey;
   // Propagate standard callbacks (subclasses propagate any extras after
   // calling super).
   copy.onLoopToggled = _onLoopToggled;

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView_Private.h
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Inspector/KKTimelineInspectorView_Private.h
@@ -103,6 +103,10 @@ NS_ASSUME_NONNULL_BEGIN
   NSButton *_paramOrderButton;
   NSPopover *_paramOrderPopover;
   BOOL _showsParamOrderRow;
+  KKParameterRowView *_presetsRow;
+  NSButton *_presetsButton;
+  id _presetsPopover;
+  BOOL _showsPresetsRow;
   double _mbShutterAngle;
   NSInteger _mbSamples;
   KKMotionBlurMode _mbMode;
@@ -135,7 +139,23 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)_buildMotionBlurRow;
 - (void)_buildOSCVisibilityRow;
 - (void)_buildParamOrderRow;
+- (void)_buildPresetsRow;
 - (void)_installConstraints:(NSView *)box headerRow:(NSView *)headerRow;
+/// Shared builder for the optional rows below the box (a labeled left view + an
+/// 18pt settings gear, optionally a 12pt checkbox). Implemented in
+/// +ParameterRows; the +Presets category reuses it for the Presets row.
+- (KKParameterRowView *)
+    _buildTickGearRowWithParameterID:(UInt32)parameterID
+                          iconSymbol:(NSString *)iconSymbol
+                               title:(NSString *)title
+                   gearAccessibility:(NSString *)gearAccessibility
+                          gearAction:(SEL)gearAction
+                        showCheckbox:(BOOL)showCheckbox
+                            checkbox:
+                                (KKCheckboxView *__strong _Nullable *_Nullable)
+                                    outCheckbox
+                          gearButton:
+                              (NSButton *__strong _Nonnull *_Nonnull)outGear;
 @end
 
 // Layout constants shared between the main .m and the +ParameterRows category.
@@ -143,6 +163,7 @@ FOUNDATION_EXPORT const CGFloat kHeaderRowHeight;
 FOUNDATION_EXPORT const CGFloat kMotionBlurRowHeight;
 FOUNDATION_EXPORT const CGFloat kOSCVisibilityRowHeight;
 FOUNDATION_EXPORT const CGFloat kParamOrderRowHeight;
+FOUNDATION_EXPORT const CGFloat kPresetsRowHeight;
 FOUNDATION_EXPORT const CGFloat kMBCheckboxTrailing;
 
 NS_ASSUME_NONNULL_END

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Lanes/KKTimelineLanesView.h
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Lanes/KKTimelineLanesView.h
@@ -54,6 +54,11 @@ typedef NS_ENUM(NSInteger, KKMiniViewerRenderMode) {
 /// render tick. Forwarded to the Basic motion graph.
 - (void)setPlayheadFraction:(double)frac;
 
+/// Current playhead position as a clip fraction (0–1), or < 0 when hidden /
+/// unknown. Read from the Basic motion graph; used by "apply preset at
+/// playhead".
+@property(nonatomic, readonly) double playheadFraction;
+
 /// The current timeline state. KVO-unsafe; read only from the main queue.
 @property(nonatomic, readonly) KKTimeline *currentTimeline;
 

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/Lanes/KKTimelineLanesView.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/Lanes/KKTimelineLanesView.m
@@ -711,6 +711,10 @@ static KKHoldForwardBlock KKMakeHoldForwarder(KKTimelineLanesView *owner) {
   [_advancedGraph setPlayheadFraction:frac];
 }
 
+- (double)playheadFraction {
+  return _basicGraph.playheadFraction;
+}
+
 - (void)resetZoom {
   // Both tabs share one toolbar button - reset whichever is active.
   if (_activeTab == 1)


### PR DESCRIPTION
Includes a new shared guide and docs for the new feature.

Bugs/changes
- [x] reduce spacing between on-screen controls, motion blur, parameter order, presets lanes as they are far apart
- [x] selected/pill on right edge is cut off due to padding of container… the pill should just overflow same as the scrubber thumb :/ also the scrubber (and snap) goes to the very end rather than the visual end like the pill

https://github.com/user-attachments/assets/a6dc5666-b868-4dbc-9e61-82efd369d212