### PR TITLE
Local LLM support

### DIFF
--- a/Canvas/Canvas/Plugin/LayerList/LayerList_Private.h
+++ b/Canvas/Canvas/Plugin/LayerList/LayerList_Private.h
@@ -23,9 +23,9 @@ static const CGFloat kLayerBorderAlpha __attribute__((unused)) = 0.05;
 static const CGFloat kLayerGroupIndent __attribute__((unused)) = 18.0;
 
 static NSString *const _Nonnull kLayerDragType __attribute__((unused)) =
-    @"com.overpolish.canvas.layerDrag";
+    @"co.overpolish.canvas.layerDrag";
 static NSString *const _Nonnull kLayerDuplicateDragType
-    __attribute__((unused)) = @"com.overpolish.canvas.layerDuplicateDrag";
+    __attribute__((unused)) = @"co.overpolish.canvas.layerDuplicateDrag";
 
 @class KKCapStyleView;
 @class KKCustomGroupHeaderView;

--- a/Keyframeless X/Keyframeless X.xcodeproj/project.pbxproj
+++ b/Keyframeless X/Keyframeless X.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		F207778B2FA3FD7B00AA4E71 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = F207778A2FA3FD7B00AA4E71 /* FluidAudio */; };
+		F20AACB42FD728000032F7FF /* KeyframelessAI in Frameworks */ = {isa = PBXBuildFile; productRef = F20AACB32FD728000032F7FF /* KeyframelessAI */; };
+		F20AACB82FD7281C0032F7FF /* kk-ai-helper in CopyFiles */ = {isa = PBXBuildFile; fileRef = F20AACAC2FD727B00032F7FF /* kk-ai-helper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F23EEFDA2FC893D500AFBA1E /* KeyframelessAI in Frameworks */ = {isa = PBXBuildFile; productRef = F23EEFD92FC893D500AFBA1E /* KeyframelessAI */; };
 		F274D93A2F6E7AC2001FE373 /* Profanity in Resources */ = {isa = PBXBuildFile; fileRef = F274D9392F6E7AC2001FE373 /* Profanity */; };
 		F28BD2302F68595000C5F6B7 /* KeyframelessKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F28BD22F2F68595000C5F6B7 /* KeyframelessKit.framework */; };
@@ -18,6 +20,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		F20AACB52FD728100032F7FF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F29C84BE2F68205E0073B1A9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F20AACAB2FD727B00032F7FF;
+			remoteInfo = "kk-ai-helper";
+		};
 		F29C84EB2F6820750073B1A9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F29C84BE2F68205E0073B1A9 /* Project object */;
@@ -28,6 +37,25 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		F20AACAA2FD727B00032F7FF /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		F20AACB72FD728120032F7FF /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 6;
+			files = (
+				F20AACB82FD7281C0032F7FF /* kk-ai-helper in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F28BD2322F68595000C5F6B7 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -53,6 +81,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F20AACAC2FD727B00032F7FF /* kk-ai-helper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "kk-ai-helper"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F274D9392F6E7AC2001FE373 /* Profanity */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Profanity; path = "Keyframeless X FCP/Resources/Profanity"; sourceTree = "<group>"; };
 		F28BD22F2F68595000C5F6B7 /* KeyframelessKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = KeyframelessKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F29C84C62F68205E0073B1A9 /* Keyframeless X.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Keyframeless X.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -96,6 +125,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		F20AACAD2FD727B00032F7FF /* kk-ai-helper */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "kk-ai-helper";
+			sourceTree = "<group>";
+		};
 		F29C84C82F68205E0073B1A9 /* Keyframeless X */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "Keyframeless X";
@@ -112,6 +146,14 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		F20AACA92FD727B00032F7FF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F20AACB42FD728000032F7FF /* KeyframelessAI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F29C84C32F68205E0073B1A9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -148,6 +190,7 @@
 				F274D9392F6E7AC2001FE373 /* Profanity */,
 				F29C84C82F68205E0073B1A9 /* Keyframeless X */,
 				F29C84E12F6820750073B1A9 /* Keyframeless X FCP */,
+				F20AACAD2FD727B00032F7FF /* kk-ai-helper */,
 				F28BD22E2F68595000C5F6B7 /* Frameworks */,
 				F29C84C72F68205E0073B1A9 /* Products */,
 			);
@@ -158,6 +201,7 @@
 			children = (
 				F29C84C62F68205E0073B1A9 /* Keyframeless X.app */,
 				F29C84E02F6820750073B1A9 /* Keyframeless X FCP.appex */,
+				F20AACAC2FD727B00032F7FF /* kk-ai-helper */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -165,6 +209,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		F20AACAB2FD727B00032F7FF /* kk-ai-helper */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F20AACB22FD727B00032F7FF /* Build configuration list for PBXNativeTarget "kk-ai-helper" */;
+			buildPhases = (
+				F20AACA82FD727B00032F7FF /* Sources */,
+				F20AACA92FD727B00032F7FF /* Frameworks */,
+				F20AACAA2FD727B00032F7FF /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F20AACAD2FD727B00032F7FF /* kk-ai-helper */,
+			);
+			name = "kk-ai-helper";
+			packageProductDependencies = (
+				F20AACB32FD728000032F7FF /* KeyframelessAI */,
+			);
+			productName = "kk-ai-helper";
+			productReference = F20AACAC2FD727B00032F7FF /* kk-ai-helper */;
+			productType = "com.apple.product-type.tool";
+		};
 		F29C84C52F68205E0073B1A9 /* Keyframeless X */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F29C84D12F68205F0073B1A9 /* Build configuration list for PBXNativeTarget "Keyframeless X" */;
@@ -197,10 +264,12 @@
 				F29C84DD2F6820750073B1A9 /* Frameworks */,
 				F29C84DE2F6820750073B1A9 /* Resources */,
 				F28BD2322F68595000C5F6B7 /* Embed Frameworks */,
+				F20AACB72FD728120032F7FF /* CopyFiles */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				F20AACB62FD728100032F7FF /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				F29C84E12F6820750073B1A9 /* Keyframeless X FCP */,
@@ -223,9 +292,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 2630;
+				LastSwiftUpdateCheck = 2650;
 				LastUpgradeCheck = 2640;
 				TargetAttributes = {
+					F20AACAB2FD727B00032F7FF = {
+						CreatedOnToolsVersion = 26.5;
+					};
 					F29C84C52F68205E0073B1A9 = {
 						CreatedOnToolsVersion = 26.3;
 					};
@@ -261,6 +333,7 @@
 			targets = (
 				F29C84C52F68205E0073B1A9 /* Keyframeless X */,
 				F29C84DF2F6820750073B1A9 /* Keyframeless X FCP */,
+				F20AACAB2FD727B00032F7FF /* kk-ai-helper */,
 			);
 		};
 /* End PBXProject section */
@@ -284,6 +357,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		F20AACA82FD727B00032F7FF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F29C84C22F68205E0073B1A9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -301,6 +381,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		F20AACB62FD728100032F7FF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F20AACAB2FD727B00032F7FF /* kk-ai-helper */;
+			targetProxy = F20AACB52FD728100032F7FF /* PBXContainerItemProxy */;
+		};
 		F29C84EC2F6820750073B1A9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = F29C84DF2F6820750073B1A9 /* Keyframeless X FCP */;
@@ -309,6 +394,34 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		F20AACB02FD727B00032F7FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F20AACB12FD727B00032F7FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		F29C84CF2F68205F0073B1A9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -438,13 +551,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = keyframeless;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_ENTITLEMENTS = "Keyframeless X/Keyframeless X.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = 378WQ9W95U;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -475,13 +588,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = keyframeless;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_ENTITLEMENTS = "Keyframeless X/Keyframeless X.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = 378WQ9W95U;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -515,13 +628,11 @@
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Keyframeless X FCP/Keyframeless_X_FCP.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = 378WQ9W95U;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_FILE_ACCESS_MOVIES_FOLDER = readwrite;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -565,6 +676,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "co.overpolish.keyframeless.Keyframeless-X.Keyframeless-X-FCP";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
 				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
 				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
 				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
@@ -590,13 +702,11 @@
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Keyframeless X FCP/Keyframeless_X_FCP.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = 378WQ9W95U;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_FILE_ACCESS_MOVIES_FOLDER = readwrite;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -640,6 +750,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "co.overpolish.keyframeless.Keyframeless-X.Keyframeless-X-FCP";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
 				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
 				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
 				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
@@ -660,6 +771,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		F20AACB22FD727B00032F7FF /* Build configuration list for PBXNativeTarget "kk-ai-helper" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F20AACB02FD727B00032F7FF /* Debug */,
+				F20AACB12FD727B00032F7FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F29C84C12F68205E0073B1A9 /* Build configuration list for PBXProject "Keyframeless X" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -721,6 +841,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F20777892FA3FD7B00AA4E71 /* XCRemoteSwiftPackageReference "FluidAudio" */;
 			productName = FluidAudio;
+		};
+		F20AACB32FD728000032F7FF /* KeyframelessAI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KeyframelessAI;
 		};
 		F23EEFD92FC893D500AFBA1E /* KeyframelessAI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Keyframeless X/Keyframeless X/Keyframeless X.entitlements
+++ b/Keyframeless X/Keyframeless X/Keyframeless X.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Keyframeless X/kk-ai-helper/main.swift
+++ b/Keyframeless X/kk-ai-helper/main.swift
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import KeyframelessAI
+
+LocalAIHelperServer.run()

--- a/KeyframelessAI/Package.resolved
+++ b/KeyframelessAI/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "6dd8165ee44bb8afd7f1bd1a6eef59ac668b25c76dc561ce69b16e6d375c8072",
+  "originHash" : "b09d237dc6b03438ba733d153ed3382a798f14d1891121c41b081ee51520892e",
   "pins" : [
-    {
-      "identity" : "cocoalumberjack",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack",
-      "state" : {
-        "revision" : "a9ed4b6f9bdedce7d77046f43adfb8ce1fd54114",
-        "version" : "3.9.0"
-      }
-    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -17,15 +8,6 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "fluidaudio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/FluidInference/FluidAudio",
-      "state" : {
-        "revision" : "d302273d49ef4d8914b27f20d342be482e8810f1",
-        "version" : "0.14.1"
       }
     },
     {
@@ -44,15 +26,6 @@
       "state" : {
         "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
         "version" : "3.31.3"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
-        "version" : "1.7.1"
       }
     },
     {
@@ -110,15 +83,6 @@
       }
     },
     {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log",
-      "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
-      }
-    },
-    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
@@ -161,24 +125,6 @@
       "state" : {
         "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
         "version" : "1.3.3"
-      }
-    },
-    {
-      "identity" : "swiftwhisper",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/exPHAT/SwiftWhisper",
-      "state" : {
-        "revision" : "a192004db08de7c6eaa169eede77f1625e7d23fb",
-        "version" : "1.2.0"
-      }
-    },
-    {
-      "identity" : "whisperkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/argmaxinc/WhisperKit",
-      "state" : {
-        "branch" : "main",
-        "revision" : "94cf6b120cf9dde32d9dea01acc326e77371302c"
       }
     },
     {

--- a/KeyframelessAI/Package.swift
+++ b/KeyframelessAI/Package.swift
@@ -8,9 +8,38 @@ let package = Package(
 	products: [
 		.library(name: "KeyframelessAI", targets: ["KeyframelessAI"])
 	],
+	dependencies: [
+		// Apple's official MLX Swift LLM stack (in-process, Apple-Silicon).
+		// 3.31.3 adds Gemma 4 (gemma4 / gemma4_text) and, crucially, drops the
+		// swift-transformers dependency (it ships its own MLXHuggingFace), which
+		// clears the long-standing version clash with WhisperKit in Steno.
+		// Structured output no longer needs the third-party XGrammar package:
+		// 3.x has native tool-calling (ToolSpec + ToolCallProcessor + per-model
+		// parsers), which we use to coax valid JSON out of the local model.
+		.package(url: "https://github.com/ml-explore/mlx-swift-lm", exact: "3.31.3"),
+		// 3.x decouples the Hub/tokenizer impl from mlx (no more pinned
+		// swift-transformers). The consumer supplies them; the MLXHuggingFace
+		// macros adapt these into mlx's Downloader / TokenizerLoader. Versions
+		// per the mlx-swift-lm 3.31.3 README.
+		.package(
+			url: "https://github.com/huggingface/swift-huggingface", .upToNextMajor(from: "0.9.0")),
+		.package(
+			url: "https://github.com/huggingface/swift-transformers", .upToNextMajor(from: "1.3.0")),
+	],
 	targets: [
 		.target(
 			name: "KeyframelessAI",
+			dependencies: [
+				.product(name: "MLXLLM", package: "mlx-swift-lm"),
+				// VLM factory for MoE/multimodal Gemma 4 (26B-A4B) - its MoE blocks
+				// are only implemented on the VLM side, not the dense LLM Gemma4.
+				.product(name: "MLXVLM", package: "mlx-swift-lm"),
+				.product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+				// 3.x downloader/tokenizer macros (#hubDownloader / #huggingFaceTokenizerLoader).
+				.product(name: "MLXHuggingFace", package: "mlx-swift-lm"),
+				.product(name: "HuggingFace", package: "swift-huggingface"),
+				.product(name: "Tokenizers", package: "swift-transformers"),
+			],
 			path: "Sources/KeyframelessAI",
 			resources: [.process("Resources")]
 		)

--- a/KeyframelessAI/README.md
+++ b/KeyframelessAI/README.md
@@ -1,0 +1,77 @@
+# KeyframelessAI
+
+Shared AI layer for the suite. Cloud providers (Claude and ChatGPT, BYOK) work the moment you link the package. Local (on-device, Apple MLX) needs per-target wiring, below.
+
+Plugins call `AIPluginAgent` (natural language to timeline mutations, plus streaming Q&A); Steno calls `AIRouter` / `AITransform` (caption edits, plus a streaming Q&A route). Both reach local inference through one shared helper.
+
+## Local inference
+
+On-device inference runs in a single out-of-process helper (`kk-ai-helper`), not in the calling process: the FCP workflow extension is killed at its ~1 GB watermark if it loads MLX in-process, and per-instance loads would each cost ~16 GB. One helper, one model load, serves every plugin and extension.
+
+```mermaid
+flowchart TB
+    subgraph plugin ["FxPlug plugin (XPC Service)"]
+        PA["AI: AIPluginAgent"]
+    end
+
+    subgraph ext ["Workflow extension, e.g. Steno (.appex)"]
+        TR["Transcription<br/>WhisperKit / Parakeet (CoreML)<br/>in-process, separate from the LLM"]
+        AX["AI: AIRouter / AITransform"]
+    end
+
+    subgraph group ["App Group: group.co.overpolish.keyframeless"]
+        SOCK(["kkai.sock"])
+        CACHE[("HF model cache")]
+    end
+
+    HELPER["kk-ai-helper<br/>shared LLM process (MLX)<br/>first client spawns it"]
+    MODEL[("LLM weights<br/>loaded once")]
+
+    PA -->|JSON over UDS| SOCK
+    AX -->|JSON over UDS| SOCK
+    HELPER -.->|binds + listens| SOCK
+    HELPER --> MODEL
+    HELPER -->|reads| CACHE
+```
+
+It binds a Unix socket in the app-group container (`group.co.overpolish.keyframeless/kkai.sock`). The first client spawns it from its own bundle; the rest connect. The open connection is the ref-count, so when the last client disconnects the helper idle-exits after 30 min (an open client keeps it alive). The HF model cache lives in the same app-group container, so whoever spawns the helper finds the downloaded model. Streaming and status ("Loading model", "Thinking") flow back over the socket automatically.
+
+`LocalLLM.defaultRunner()` picks the engine, no code changes needed:
+
+- app-group reachable: `SharedHelperRunner` (the shared helper), plugins and the extension alike
+- no app group, `.appex`: `nil` (local disabled, never an in-process crash)
+- no app group, plugin: `MLXLocalLLMRunner` (in-process)
+
+## Wiring a new client
+
+Per client target. Each separate Xcode project needs its own helper target (a project can't embed another's product).
+
+1. Link the `KeyframelessAI` library.
+2. Add a Command Line Tool target `kk-ai-helper`.
+   - Replace Xcode's `Hello, World!` `main.swift` with `import KeyframelessAI` then `LocalAIHelperServer.run()`,
+   - Link the library.
+   - No entitlements (it gets the socket path via `--socket`).
+3. Embed it
+   - Copy Files - destination Executables with Code Sign On Copy in the process that runs inference:
+     - the XPC Service target for an FxPlug plugin,
+     - the `.appex` for an extension. It must land in that bundle's `Contents/MacOS/`.
+4. Add the App Group `group.co.overpolish.keyframeless` and turn on Automatic signing.
+
+> [!IMPORTANT]
+> Add the App Group via Signing & Capabilities, not by editing `.entitlements` (the profile won't get the capability and the build fails with "requires a provisioning profile with the App Groups feature"). Put it on the app-level target: the containing app for an extension, the Wrapper Application for a plugin (an XPC Service target can't take App Groups in the UI). The child reaches the container through it. Automatic signing must be on across the whole embed chain or the embedded helper fails the parent-certificate check.
+
+## Models
+
+Model state is in-process; the helper is inference-only. Drive `LocalModelStore.shared` (`download`, `select`, `uninstall`, `selectedModelID`, `hasReadyModel`) or present `LocalModelsView`; the catalog is `LocalModelCatalog.models`.
+
+Local is gated to Apple Silicon with 24 GB+ RAM (`AIPlatform.supportsLocal`); below that, `.local` is hidden and clients use the cloud providers.
+
+## Logs
+
+Subsystem `co.overpolish.keyframeless`, categories `ai.helper` (routing, spawn, socket) and `ai.local` (load and generation timings):
+
+```sh
+log show --last 5m --predicate 'subsystem == "co.overpolish.keyframeless"' --info
+```
+
+`spawn FAILED` or "did not come up" means the helper isn't embedded in this client's bundle, or it's still the Hello-World stub. `extension has no app-group socket` means the App Group isn't registered on the app-level target.

--- a/KeyframelessAI/Sources/KeyframelessAI/Keychain/AIKeyState.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Keychain/AIKeyState.swift
@@ -25,14 +25,30 @@ public final class AIKeyState: ObservableObject {
 	private init() {
 		let saved = UserDefaults.standard.string(forKey: Self.activeKey)
 			.flatMap(AIProvider.init(rawValue:))
-		activeProvider = saved ?? .anthropic
+		// Default to Local where it's supported (Apple Silicon, >=16 GB) -
+		// privacy-first, no key needed; cloud otherwise (Intel / low-RAM, where
+		// Local is hidden). A saved choice always wins.
+		activeProvider = saved ?? (AIPlatform.supportsLocal ? .local : .anthropic)
 		refresh()
 	}
 
 	public func refresh() {
-		configuredProviders = AIKeychain.providersWithKeys()
+		var providers = AIKeychain.providersWithKeys()
+		// The local provider has no key; it's "configured" once a model is
+		// downloaded and selected. Only where local is supported (Apple Silicon,
+		// >=16 GB RAM).
+		if AIPlatform.supportsLocal, LocalModelStore.shared.hasReadyModel {
+			providers.append(.local)
+		}
+		configuredProviders = providers
 
-		if !configuredProviders.isEmpty, !configuredProviders.contains(activeProvider) {
+		// Auto-pick a configured provider only when the active one is an
+		// unconfigured CLOUD provider (e.g. its key was deleted). Never bounce
+		// the user off `.local`: sitting on it with no model yet is a valid
+		// state - the config tab is where they download one.
+		if !configuredProviders.isEmpty, activeProvider != .local,
+			!configuredProviders.contains(activeProvider)
+		{
 			activeProvider = configuredProviders.first!
 		}
 	}

--- a/KeyframelessAI/Sources/KeyframelessAI/Keychain/AIKeyState.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Keychain/AIKeyState.swift
@@ -20,7 +20,7 @@ public final class AIKeyState: ObservableObject {
 	public var hasAnyKey: Bool { !configuredProviders.isEmpty }
 	public var activeIsConfigured: Bool { configuredProviders.contains(activeProvider) }
 
-	private static let activeKey = "com.overpolish.ai.activeProvider"
+	private static let activeKey = "co.overpolish.ai.activeProvider"
 
 	private init() {
 		let saved = UserDefaults.standard.string(forKey: Self.activeKey)

--- a/KeyframelessAI/Sources/KeyframelessAI/Keychain/AIKeyValidator.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Keychain/AIKeyValidator.swift
@@ -30,6 +30,10 @@ public enum AIKeyValidator {
 		case .openai:
 			request = URLRequest(url: URL(string: "https://api.openai.com/v1/models")!)
 			request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+		case .local:
+			// No remote key to validate; the local provider is gated on a
+			// downloaded model instead.
+			return
 		}
 		request.timeoutInterval = 15
 

--- a/KeyframelessAI/Sources/KeyframelessAI/Keychain/AIKeychain.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Keychain/AIKeychain.swift
@@ -7,7 +7,7 @@ public enum AIKeychainError: Error {
 }
 
 public enum AIKeychain {
-    private static let service = "com.overpolish.ai-keys"
+    private static let service = "co.overpolish.ai-keys"
 
     public static func save(_ key: String, for provider: AIProvider) throws {
         guard let data = key.data(using: .utf8) else {

--- a/KeyframelessAI/Sources/KeyframelessAI/Knowledge/AIKnowledge.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Knowledge/AIKnowledge.swift
@@ -47,4 +47,48 @@ public final class AIKnowledgeRegistry {
 		}
 		return result
 	}
+
+	/// The topics most relevant to `prompt`, capped at `limit`. Dumping the WHOLE
+	/// knowledge base into a local model's prompt is the single biggest cost on
+	/// device: a ~10k-token context takes ~70s to prefill for a one-line answer,
+	/// while decode itself runs at 30+ tok/s. Cheap lexical scoring (word overlap,
+	/// no embeddings) keeps only the handful of topics that actually match, so the
+	/// prompt drops to ~1-2k tokens. Matches in the short, representative
+	/// id/summary outweigh body matches. Falls back to the first `limit` entries
+	/// when the prompt shares no terms (e.g. "what does this do") so a general
+	/// question still gets some context.
+	public func relevantEntries(
+		to prompt: String, limit: Int
+	) async -> [(source: String, topic: AIKnowledgeTopic)] {
+		let all = await allEntries()
+		let terms = Self.queryTerms(prompt)
+		guard !terms.isEmpty, all.count > limit else { return Array(all.prefix(limit)) }
+		func score(_ e: (source: String, topic: AIKnowledgeTopic)) -> Int {
+			let head = (e.topic.id + " " + e.topic.summary).lowercased()
+			let body = e.topic.content.lowercased()
+			var s = 0
+			for t in terms {
+				if head.contains(t) { s += 3 }
+				if body.contains(t) { s += 1 }
+			}
+			return s
+		}
+		let ranked = all.map { (entry: $0, score: score($0)) }
+			.sorted { $0.score > $1.score }
+		let hits = ranked.filter { $0.score > 0 }.map { $0.entry }
+		return hits.isEmpty ? Array(all.prefix(limit)) : Array(hits.prefix(limit))
+	}
+
+	private static func queryTerms(_ s: String) -> [String] {
+		let stop: Set<String> = [
+			"the", "and", "are", "for", "does", "what", "how", "why", "this", "that",
+			"with", "can", "you", "your", "its", "has", "have", "will", "when", "where",
+		]
+		return Set(
+			s.lowercased()
+				.split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+				.map(String.init)
+				.filter { $0.count > 2 && !stop.contains($0) }
+		).sorted()
+	}
 }

--- a/KeyframelessAI/Sources/KeyframelessAI/PluginAgent/AIPluginAgent.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/PluginAgent/AIPluginAgent.swift
@@ -103,7 +103,7 @@ public final class AIPluginAgent: NSObject {
 		let classification = try await classify(
 			prompt: prompt, productContext: productContext, laneLabels: labels)
 		if classification.kind == "answer" {
-			let docs = await renderDocs()
+			let docs = await renderDocs(for: prompt)
 			let reply = try await answerQuestion(
 				prompt: prompt, productContext: productContext, docs: docs)
 			return AIPluginResult(answer: reply)

--- a/KeyframelessAI/Sources/KeyframelessAI/PluginAgent/AIPluginAgent.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/PluginAgent/AIPluginAgent.swift
@@ -90,7 +90,7 @@ public final class AIPluginAgent: NSObject {
 		clipDurationSeconds: Double,
 		currentInspectorMode: String
 	) async throws -> AIPluginResult {
-		AIDraftState.shared.routingStatus = AILoc("Reading prompt…")
+		AIDraftState.shared.routingStatus = AILoc("Reading prompt")
 		// Pass 0a: classify. No docs in this prompt - classifier is just a
 		// router. If the answer path wins, Pass 0b loads docs and writes the
 		// reply. This keeps the mutation path (the hot path) cheap. We
@@ -134,7 +134,7 @@ public final class AIPluginAgent: NSObject {
 			return AIPluginResult(mutationJSON: templated)
 		}
 
-		AIDraftState.shared.routingStatus = AILoc("Planning timing…")
+		AIDraftState.shared.routingStatus = AILoc("Planning timing")
 		// Pass 1: timing. Thinking only when the classifier flagged the prompt
 		// as "complex" - simple template-matchable prompts don't need 4k
 		// reasoning tokens.
@@ -171,7 +171,7 @@ public final class AIPluginAgent: NSObject {
 		for (opIdx, op) in effectiveOperations.enumerated() {
 			let suffix = totalOps > 1 ? " (\(opIdx + 1)/\(totalOps))" : ""
 			let laneLabel = "\(op.lane)\(suffix)"
-			AIDraftState.shared.routingStatus = AILoc("Resolving \(laneLabel)…")
+			AIDraftState.shared.routingStatus = AILoc("Resolving \(laneLabel)")
 			let oldKeyposes = currentLanes[op.lane] ?? []
 			let oldIntervals = currentIntervals[op.lane] ?? []
 			async let valuesAsync = resolveValues(

--- a/KeyframelessAI/Sources/KeyframelessAI/PluginAgent/PluginAgent+Classifier.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/PluginAgent/PluginAgent+Classifier.swift
@@ -133,7 +133,13 @@ extension AIPluginAgent {
 			jsonSchema: schema,
 			modelOverride: AIKeyState.shared.activeProvider == .anthropic
 				? "claude-haiku-4-5-20251001"
-				: "gpt-4o-mini"
+				: "gpt-4o-mini",
+			// Cloud models route correctly in a single grammar-constrained pass.
+			// A small local model can't: it has to emit `kind` as its first token
+			// with no room to reason, and flips clear mutations to "answer". Give
+			// local the two-pass (reason freely, then format) treatment so routing
+			// is reliable - it's the decision the whole pipeline hinges on.
+			enableThinking: AIKeyState.shared.activeProvider == .local
 		)
 		let data = raw.data(using: .utf8) ?? Data()
 		let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]

--- a/KeyframelessAI/Sources/KeyframelessAI/PluginAgent/PluginAgent+Classifier.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/PluginAgent/PluginAgent+Classifier.swift
@@ -31,10 +31,33 @@ extension AIPluginAgent {
 		let templateModulation: String
 	}
 
+	/// A plainly-phrased question (ends with "?", opens with a question word).
+	/// Routes straight to the answer path, skipping the classify LLM call - one
+	/// fewer ~100 tok/s prefill pass, and it avoids small models misrouting a
+	/// question to "mutation". Commands ("spin once", "move left") don't match, so
+	/// they still go through the classifier.
+	static func looksLikeQuestion(_ prompt: String) -> Bool {
+		let t = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard t.hasSuffix("?") else { return false }
+		let first = String(t.lowercased().prefix(while: { $0.isLetter }))
+		let qWords: Set<String> = [
+			"what", "whats", "how", "hows", "why", "when", "where", "who", "whos",
+			"which", "whose", "whom", "can", "could", "does", "do", "did", "is",
+			"are", "am", "was", "were", "will", "would", "should", "explain", "tell",
+		]
+		return qWords.contains(first)
+	}
+
 	@MainActor
 	static func classify(
 		prompt: String, productContext: String, laneLabels: [String]
 	) async throws -> Classification {
+		// Obvious questions bypass the (locally expensive) LLM router.
+		if looksLikeQuestion(prompt) {
+			return Classification(
+				kind: "answer", complexity: "simple", clarification: nil,
+				template: "none", templateLane: "", templateModulation: "")
+		}
 		let laneList =
 			laneLabels.isEmpty
 			? "(no lanes available)"
@@ -167,6 +190,28 @@ extension AIPluginAgent {
 			or <...> style symbols; the answer is shown as plain text. If the docs \
 			don't cover the question, say so briefly.
 			"""
+		// Local: answer as PLAIN TEXT. Small models reliably write good prose but
+		// routinely fail to wrap it in a {answer:...} JSON envelope - which surfaces
+		// as "didn't return JSON" AND triggers a retry of the whole (slow) prefill,
+		// doubling latency for nothing. The prose IS the answer, so skip the wrapper.
+		if AIKeyState.shared.activeProvider == .local {
+			guard let runner = LocalLLM.runner else { throw AITransformError.localUnavailable }
+			let combined = docs.isEmpty ? system : (docs + "\n\n" + system)
+			let modelID = LocalModelStore.shared.selectedModelID ?? ""
+			// Stream the reply straight into the popover's answer card so the user
+			// reads it as it's written, rather than waiting for the whole thing.
+			AIDraftState.shared.pendingAnswer = nil
+			var acc = ""
+			for try await chunk in await runner.completeStreaming(
+				modelID: modelID, system: combined, user: prompt)
+			{
+				acc += chunk
+				AIDraftState.shared.pendingAnswer = acc
+			}
+			let final = MLXLocalLLMRunner.stripThink(acc)
+			AIDraftState.shared.pendingAnswer = final
+			return final
+		}
 		let schema: [String: Any] = [
 			"type": "object",
 			"additionalProperties": false,

--- a/KeyframelessAI/Sources/KeyframelessAI/PluginAgent/PluginAgent+State.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/PluginAgent/PluginAgent+State.swift
@@ -72,8 +72,15 @@ extension AIPluginAgent {
 	}
 
 	@MainActor
-	static func renderDocs() async -> String {
-		let entries = await AIKnowledgeRegistry.shared.allEntries()
+	static func renderDocs(for prompt: String) async -> String {
+		// Local models prefill slowly, so retrieve only the topics relevant to the
+		// prompt instead of dumping the whole knowledge base (a 10k-token jam costs
+		// ~70s of prefill on device). Cloud has fast prefill + a big context window,
+		// so it keeps the full docs for maximum answer quality.
+		let entries =
+			AIKeyState.shared.activeProvider == .local
+			? await AIKnowledgeRegistry.shared.relevantEntries(to: prompt, limit: 2)
+			: await AIKnowledgeRegistry.shared.allEntries()
 		guard !entries.isEmpty else { return "REFERENCE DOCS:\n(none registered)" }
 		let bySource = Dictionary(grouping: entries) { $0.source }
 		var out = "REFERENCE DOCS:\n"

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/AIPlatform.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/AIPlatform.swift
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import Darwin
+import Foundation
+
+enum AIPlatform {
+	/// True on Apple Silicon. Intel has no usable GPU path for MLX (CPU-only is
+	/// far too slow for the multi-pass pipeline), and FCP 12 is Apple-Silicon
+	/// only anyway.
+	static let isAppleSilicon: Bool = {
+		var size = 0
+		return sysctlbyname("hw.optional.arm64", nil, &size, nil, 0) == 0
+	}()
+
+	/// Installed physical RAM in whole GB.
+	static let physicalMemoryGB: Int = Int(
+		ProcessInfo.processInfo.physicalMemory / 1_073_741_824)
+
+	/// Whether local inference is offered at all: Apple Silicon AND >=16 GB RAM.
+	/// Below 16 GB the smallest worthwhile model (Qwen 9B) leaves no headroom for
+	/// FCP and the quality isn't worth it - those users get the cloud (BYOK)
+	/// providers instead.
+	static let supportsLocal: Bool = isAppleSilicon && physicalMemoryGB >= 16
+}

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/AIPlatform.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/AIPlatform.swift
@@ -19,9 +19,14 @@ enum AIPlatform {
 	static let physicalMemoryGB: Int = Int(
 		ProcessInfo.processInfo.physicalMemory / 1_073_741_824)
 
-	/// Whether local inference is offered at all: Apple Silicon AND >=16 GB RAM.
-	/// Below 16 GB the smallest worthwhile model (Qwen 9B) leaves no headroom for
-	/// FCP and the quality isn't worth it - those users get the cloud (BYOK)
-	/// providers instead.
-	static let supportsLocal: Bool = isAppleSilicon && physicalMemoryGB >= 16
+	/// Minimum installed RAM to offer local inference. The catalog is all-MoE
+	/// (big-model quality at low compute, but ALL experts stay resident ~16 GB),
+	/// so 24 GB is the real floor: less than that swaps against FCP. Smaller dense
+	/// models were dropped (transform quality wasn't worth it). A hard gate, same
+	/// spirit as the Intel gate - under-spec machines use cloud (BYOK) instead;
+	/// that's a fundamental limitation of local LLMs, not a bug.
+	static let minLocalRAMGB = 24
+
+	/// Whether local inference is offered at all: Apple Silicon AND >= 24 GB RAM.
+	static let supportsLocal: Bool = isAppleSilicon && physicalMemoryGB >= minLocalRAMGB
 }

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/AIProvider.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/AIProvider.swift
@@ -9,7 +9,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Sendable {
 	public var id: String { rawValue }
 
 	/// Cases offered to the user. Local is hidden unless the machine supports it
-	/// (Apple Silicon with >=16 GB RAM); otherwise only the cloud providers show.
+	/// (Apple Silicon with >= 24 GB RAM); otherwise only the cloud providers show.
 	public static var availableCases: [AIProvider] {
 		AIPlatform.supportsLocal ? allCases : allCases.filter { $0 != .local }
 	}

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/AIProvider.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/AIProvider.swift
@@ -1,29 +1,51 @@
 import Foundation
 
 public enum AIProvider: String, CaseIterable, Identifiable, Sendable {
+	// Order drives the picker; Local is listed first (Apple Silicon only).
+	case local
 	case anthropic
 	case openai
 
 	public var id: String { rawValue }
 
+	/// Cases offered to the user. Local is hidden unless the machine supports it
+	/// (Apple Silicon with >=16 GB RAM); otherwise only the cloud providers show.
+	public static var availableCases: [AIProvider] {
+		AIPlatform.supportsLocal ? allCases : allCases.filter { $0 != .local }
+	}
+
 	public var displayName: String {
 		switch self {
 		case .anthropic: return "Claude"
 		case .openai: return "ChatGPT"
+		case .local: return AILoc("Local")
 		}
 	}
 
-	public var keyConsoleURL: URL {
+	/// Cloud providers authenticate with a BYOK API key. The local provider
+	/// authenticates with nothing - it's gated on a downloaded model instead -
+	/// so the key-entry plumbing (Keychain, validator, console link) is skipped
+	/// for it and the config tab shows a model-manager view instead.
+	public var requiresAPIKey: Bool {
 		switch self {
-		case .anthropic: return URL(string: "https://console.anthropic.com/settings/keys")!
-		case .openai: return URL(string: "https://platform.openai.com/api-keys")!
+		case .anthropic, .openai: return true
+		case .local: return false
 		}
 	}
 
-	public var keyPrefixHint: String {
+	public var keyConsoleURL: URL? {
+		switch self {
+		case .anthropic: return URL(string: "https://console.anthropic.com/settings/keys")
+		case .openai: return URL(string: "https://platform.openai.com/api-keys")
+		case .local: return nil
+		}
+	}
+
+	public var keyPrefixHint: String? {
 		switch self {
 		case .anthropic: return "sk-ant-"
 		case .openai: return "sk-"
+		case .local: return nil
 		}
 	}
 }

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/AIRouter.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/AIRouter.swift
@@ -18,9 +18,74 @@ public enum AIRouter {
 		selectedCount: Int,
 		productContext: String
 	) async throws -> AIIntent {
-		// Local models prefill slowly: retrieve only the prompt-relevant topics
-		// rather than dumping the whole knowledge base (a 10k-token jam = ~70s of
-		// on-device prefill). Cloud keeps the full docs - fast prefill, big context.
+		let (system, userMessage) = await buildPrompt(
+			userPrompt, selectedCount: selectedCount, productContext: productContext)
+		let raw = try await AITransform.transform(
+			instruction: userMessage, text: "", overrideSystemPrompt: system)
+		return classify(raw)
+	}
+
+	/// Like `route`, but streams a Shape B (answer) reply into `onAnswerChunk` as
+	/// it's generated instead of returning it all at once. The decision is made from
+	/// the FIRST non-whitespace token: a transform always starts with `<TRANSFORM>`,
+	/// so a leading `<` means "buffer silently, it's a transform" and anything else
+	/// means "this is an answer, stream it". A transform never calls `onAnswerChunk`.
+	/// `onAnswerChunk` receives the cumulative answer text so far (already label-
+	/// stripped). Cloud providers don't stream token-by-token (the underlying call is
+	/// atomic), so there the answer arrives as a single final chunk - still correct,
+	/// just not incremental. The returned intent is authoritative; the final answer
+	/// reply equals the last streamed value.
+	public static func routeStreaming(
+		_ userPrompt: String,
+		selectedCount: Int,
+		productContext: String,
+		onAnswerChunk: @escaping @MainActor (String) -> Void
+	) async throws -> AIIntent {
+		let (system, userMessage) = await buildPrompt(
+			userPrompt, selectedCount: selectedCount, productContext: productContext)
+		let decision = DecisionBox()
+		let raw = try await AITransform.transformStreaming(
+			instruction: userMessage, text: "", overrideSystemPrompt: system
+		) { cumulative in
+			if decision.isTransform == nil {
+				decision.isTransform = firstShapeIsTransform(cumulative)
+			}
+			if decision.isTransform == false {
+				let shown = stripAnswerLabel(
+					cumulative.trimmingCharacters(in: .whitespacesAndNewlines))
+				await onAnswerChunk(shown)
+			}
+		}
+		return classify(raw)
+	}
+
+	/// nil until the first non-whitespace char arrives, then true if it's `<` (a
+	/// `<TRANSFORM>` tag is opening) else false (a Shape B answer).
+	private static func firstShapeIsTransform(_ cumulative: String) -> Bool? {
+		guard let first = cumulative.first(where: { !$0.isWhitespace }) else { return nil }
+		return first == "<"
+	}
+
+	private static func classify(_ raw: String) -> AIIntent {
+		let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+		if let extracted = extractTransform(from: trimmed) {
+			return .transform(instruction: extracted)
+		}
+		return .answer(reply: stripAnswerLabel(trimmed))
+	}
+
+	/// Holds the streamed transform-vs-answer decision. A reference box so the
+	/// `@Sendable` streaming callback can flip it (the callback is invoked serially).
+	private final class DecisionBox: @unchecked Sendable {
+		var isTransform: Bool?
+	}
+
+	/// Builds the routing system prompt + user message. Local models prefill slowly,
+	/// so they get only the prompt-relevant docs (a 10k-token jam = ~70s on-device);
+	/// cloud keeps the full docs (fast prefill, big context).
+	private static func buildPrompt(
+		_ userPrompt: String, selectedCount: Int, productContext: String
+	) async -> (system: String, userMessage: String) {
 		let useLocal = await MainActor.run { AIKeyState.shared.activeProvider == .local }
 		let entries =
 			useLocal
@@ -62,20 +127,8 @@ public enum AIRouter {
 			\(docsSection)
 			"""
 
-		let userMessage =
-			"[\(selectedCount) item(s) selected]\n\n\(userPrompt)"
-
-		let raw = try await AITransform.transform(
-			instruction: userMessage,
-			text: "",
-			overrideSystemPrompt: system
-		)
-		let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-
-		if let extracted = extractTransform(from: trimmed) {
-			return .transform(instruction: extracted)
-		}
-		return .answer(reply: stripAnswerLabel(trimmed))
+		let userMessage = "[\(selectedCount) item(s) selected]\n\n\(userPrompt)"
+		return (system, userMessage)
 	}
 
 	private static func stripAnswerLabel(_ raw: String) -> String {

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/AIRouter.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/AIRouter.swift
@@ -18,7 +18,14 @@ public enum AIRouter {
 		selectedCount: Int,
 		productContext: String
 	) async throws -> AIIntent {
-		let entries = await AIKnowledgeRegistry.shared.allEntries()
+		// Local models prefill slowly: retrieve only the prompt-relevant topics
+		// rather than dumping the whole knowledge base (a 10k-token jam = ~70s of
+		// on-device prefill). Cloud keeps the full docs - fast prefill, big context.
+		let useLocal = await MainActor.run { AIKeyState.shared.activeProvider == .local }
+		let entries =
+			useLocal
+			? await AIKnowledgeRegistry.shared.relevantEntries(to: userPrompt, limit: 4)
+			: await AIKnowledgeRegistry.shared.allEntries()
 		let docsSection = Self.renderDocs(entries)
 
 		let system = """

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/AIStructuredCall.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/AIStructuredCall.swift
@@ -39,6 +39,30 @@ enum AIStructuredCall {
 		enableThinking: Bool = false
 	) async throws -> String {
 		let provider = AIKeyState.shared.activeProvider
+		if provider == .local {
+			// The host's llama.cpp runner grammar-constrains output to the schema,
+			// so the model can't emit invalid JSON regardless of size. Cloud
+			// `modelOverride` is ignored; the runner loads the selected model.
+			guard let runner = LocalLLM.runner else {
+				throw AITransformError.localUnavailable
+			}
+			let combinedSystem: String
+			if let prefix = cachedSystemPrefix, !prefix.isEmpty {
+				combinedSystem = prefix + "\n\n" + system
+			} else {
+				combinedSystem = system
+			}
+			let schemaJSON =
+				(try? JSONSerialization.data(withJSONObject: jsonSchema, options: [.sortedKeys]))
+				.flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+			return try await runner.complete(
+				modelID: LocalModelStore.shared.selectedModelID ?? "",
+				system: combinedSystem,
+				user: userMessage,
+				jsonSchemaJSON: schemaJSON,
+				enableThinking: enableThinking
+			)
+		}
 		guard let key = try AIKeychain.load(provider) else {
 			throw AITransformError.noKey
 		}
@@ -82,11 +106,14 @@ enum AIStructuredCall {
 				model: openaiModel,
 				isReasoningModel: enableThinking && modelOverride == nil
 			)
+		case .local:
+			throw AITransformError.localUnavailable
 		}
 	}
 
 	// MARK: - Anthropic
 
+	@MainActor
 	private static func callAnthropic(
 		key: String, system: String, cachedPrefix: String?, userMessage: String,
 		schemaName: String, schemaDescription: String,
@@ -194,6 +221,7 @@ enum AIStructuredCall {
 
 	// MARK: - OpenAI
 
+	@MainActor
 	private static func callOpenAI(
 		key: String, system: String, userMessage: String,
 		schemaName: String, jsonSchema: [String: Any], model: String,

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/AITransform.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/AITransform.swift
@@ -27,6 +27,26 @@ public enum AITransformError: LocalizedError {
 }
 
 public enum AITransform {
+	/// Default system prompt for a plain text-transformation call (used when the
+	/// caller doesn't override it, e.g. the routing prompt does).
+	private static let defaultSystemPrompt = """
+		You are a text transformation function, not a conversational assistant.
+
+		Apply the user's instruction to the input text and output the result. \
+		Output ONLY the transformed text. No preamble, no quotes around the \
+		output, no commentary, no explanation, no apology, no questions back.
+
+		Rules:
+		- If the instruction is already satisfied (e.g. asked to translate to a \
+		language the text is already in), output the input text verbatim.
+		- If the instruction is unclear or impossible, output the input text \
+		verbatim. Do not explain.
+		- Never write phrases like "The text is already...", "Here is the...", \
+		"I cannot...". These are forbidden.
+		- Preserve word boundaries (spaces between words).
+		- Do not add or remove sentences unless the instruction explicitly says to.
+		"""
+
 	/// Run a user instruction (e.g. "translate to german", "fix capitalization")
 	/// against a plain-text input. Returns the transformed text only - no preamble,
 	/// no surrounding quotes, no commentary. Caller is responsible for re-aligning
@@ -39,24 +59,7 @@ public enum AITransform {
 	) async throws -> String {
 		let provider = await MainActor.run { AIKeyState.shared.activeProvider }
 
-		let system =
-			overrideSystemPrompt ?? """
-				You are a text transformation function, not a conversational assistant.
-
-				Apply the user's instruction to the input text and output the result. \
-				Output ONLY the transformed text. No preamble, no quotes around the \
-				output, no commentary, no explanation, no apology, no questions back.
-
-				Rules:
-				- If the instruction is already satisfied (e.g. asked to translate to a \
-				language the text is already in), output the input text verbatim.
-				- If the instruction is unclear or impossible, output the input text \
-				verbatim. Do not explain.
-				- Never write phrases like "The text is already...", "Here is the...", \
-				"I cannot...". These are forbidden.
-				- Preserve word boundaries (spaces between words).
-				- Do not add or remove sentences unless the instruction explicitly says to.
-				"""
+		let system = overrideSystemPrompt ?? Self.defaultSystemPrompt
 
 		// Mark the system prompt as cacheable when it's big enough to be worth
 		// it. Anthropic charges 125% to write the cache and 10% to read, so the
@@ -90,6 +93,47 @@ public enum AITransform {
 		case .local:
 			throw AITransformError.localUnavailable
 		}
+	}
+
+	/// Streaming sibling of `transform`. For the LOCAL provider it streams tokens
+	/// from the on-device model, invoking `onChunk` with the cumulative text so far
+	/// after each token, and returns the full text. For CLOUD providers (no SSE here)
+	/// it runs `transform` atomically and emits a single final chunk - same result,
+	/// just not incremental. `onChunk` is async so callers can hop to the main actor
+	/// to drive UI; it's awaited per token, so calls stay ordered.
+	public static func transformStreaming(
+		instruction: String,
+		text: String,
+		overrideSystemPrompt: String? = nil,
+		onChunk: @escaping @Sendable (String) async -> Void
+	) async throws -> String {
+		let provider = await MainActor.run { AIKeyState.shared.activeProvider }
+
+		if provider == .local {
+			let system = overrideSystemPrompt ?? Self.defaultSystemPrompt
+			let (runner, model) = await MainActor.run {
+				(LocalLLM.runner, LocalModelStore.shared.selectedModelID ?? "")
+			}
+			guard let runner else { throw AITransformError.localUnavailable }
+			var acc = ""
+			for try await chunk in await runner.completeStreaming(
+				modelID: model,
+				system: system,
+				user: "Instruction: \(instruction)\n\nText:\n\(text)")
+			{
+				acc += chunk
+				await onChunk(acc)
+			}
+			let trimmed = acc.trimmingCharacters(in: .whitespacesAndNewlines)
+			guard !trimmed.isEmpty else { throw AITransformError.empty }
+			return trimmed
+		}
+
+		// Cloud: no token streaming here - run atomically, emit one final chunk.
+		let full = try await transform(
+			instruction: instruction, text: text, overrideSystemPrompt: overrideSystemPrompt)
+		await onChunk(full)
+		return full
 	}
 
 	private static func callAnthropic(

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/AITransform.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/AITransform.swift
@@ -8,6 +8,7 @@ import Foundation
 public enum AITransformError: LocalizedError {
 	case noActiveProvider
 	case noKey
+	case localUnavailable
 	case http(Int, String)
 	case decoding(String)
 	case empty
@@ -16,6 +17,8 @@ public enum AITransformError: LocalizedError {
 		switch self {
 		case .noActiveProvider: return "No AI provider configured"
 		case .noKey: return "Missing API key"
+		case .localUnavailable:
+			return AILoc("Couldn't reach the on-device model service.")
 		case .http(let code, let body): return "HTTP \(code): \(body)"
 		case .decoding(let msg): return "Couldn't read response: \(msg)"
 		case .empty: return "Empty response from provider"
@@ -35,7 +38,6 @@ public enum AITransform {
 		modelOverride: String? = nil
 	) async throws -> String {
 		let provider = await MainActor.run { AIKeyState.shared.activeProvider }
-		guard let key = try AIKeychain.load(provider) else { throw AITransformError.noKey }
 
 		let system =
 			overrideSystemPrompt ?? """
@@ -61,6 +63,20 @@ public enum AITransform {
 		// breakeven is one cache hit - only worth it when system is large.
 		let cacheSystem = system.utf8.count >= 4_000
 
+		if provider == .local {
+			let (runner, model) = await MainActor.run {
+				(LocalLLM.runner, LocalModelStore.shared.selectedModelID ?? "")
+			}
+			guard let runner else { throw AITransformError.localUnavailable }
+			return try await runner.complete(
+				modelID: model,
+				system: system,
+				user: "Instruction: \(instruction)\n\nText:\n\(text)",
+				jsonSchemaJSON: nil,
+				enableThinking: false)
+		}
+		guard let key = try AIKeychain.load(provider) else { throw AITransformError.noKey }
+
 		switch provider {
 		case .anthropic:
 			return try await callAnthropic(
@@ -71,6 +87,8 @@ public enum AITransform {
 			return try await callOpenAI(
 				key: key, system: system, instruction: instruction, text: text,
 				model: modelOverride ?? "gpt-4o-mini")
+		case .local:
+			throw AITransformError.localUnavailable
 		}
 	}
 

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalAIHelperIPC.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalAIHelperIPC.swift
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import Foundation
+
+/// Wire types + framing shared by the out-of-process local-inference helper
+/// (`LocalAIHelperServer`, the child) and its client (`HelperProcessRunner`,
+/// e.g. Steno's FCP workflow extension). The extension caps at a 1 GB memory
+/// watermark that an MLX LLM load blows past, so inference is exiled to a child
+/// process spawned over a pipe - which has its own (high) limit.
+///
+/// One request -> one OR MORE responses, length-prefixed so prompt/schema strings
+/// (which contain newlines) frame unambiguously. The client serialises calls, so
+/// no request id is needed.
+///
+/// Two modes: when `stream` is nil/false the helper sends a single response with
+/// `result` (or `error`). When `stream == true` it sends a sequence of `chunk`
+/// responses as the model generates, terminated by one with `done == true` (or an
+/// `error`). Streaming is only meaningful for plain-text answers (no schema).
+struct HelperRequest: Codable {
+	let modelID: String
+	let system: String
+	let user: String
+	let jsonSchemaJSON: String?
+	let enableThinking: Bool
+	/// Stream the reply token-by-token (chunk frames) instead of one result frame.
+	/// Optional for wire-compat with a mismatched/stale helper binary (absent = off).
+	var stream: Bool? = nil
+}
+
+struct HelperResponse: Codable {
+	let result: String?
+	let error: String?
+	/// Streaming: an incremental text chunk to append (nil on the final/marker frame).
+	var chunk: String? = nil
+	/// Streaming: true on the terminating frame after the last chunk.
+	var done: Bool? = nil
+	/// Out-of-band coarse status ("Loading model…", "Thinking…") emitted before the
+	/// terminal frame so the client can show what the helper is actually doing.
+	var status: String? = nil
+}
+
+/// Length-prefixed message framing over a pipe: a 4-byte big-endian payload
+/// length, then the payload. Pipes can short-read, so both header and body are
+/// read to completion. A 0-byte read on the header is a clean EOF (peer closed).
+enum HelperFraming {
+	static func write(_ payload: Data, to fh: FileHandle) throws {
+		var len = UInt32(payload.count).bigEndian
+		var frame = Data(bytes: &len, count: 4)
+		frame.append(payload)
+		try fh.write(contentsOf: frame)
+	}
+
+	/// Returns the next payload, or nil at clean EOF (peer closed the pipe).
+	static func read(from fh: FileHandle) throws -> Data? {
+		guard let header = try readExactly(4, from: fh) else { return nil }
+		let len = UInt32(bigEndian: header.withUnsafeBytes { $0.load(as: UInt32.self) })
+		if len == 0 { return Data() }
+		guard let body = try readExactly(Int(len), from: fh) else {
+			// Header arrived but the body was truncated - peer died mid-frame.
+			throw HelperFramingError.truncated
+		}
+		return body
+	}
+
+	private static func readExactly(_ n: Int, from fh: FileHandle) throws -> Data? {
+		var buf = Data()
+		buf.reserveCapacity(n)
+		while buf.count < n {
+			let chunk = try fh.read(upToCount: n - buf.count) ?? Data()
+			if chunk.isEmpty { return buf.isEmpty ? nil : buf }
+			buf.append(chunk)
+		}
+		return buf
+	}
+}
+
+enum HelperFramingError: Error { case truncated }

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalAIHelperServer.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalAIHelperServer.swift
@@ -1,0 +1,325 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import Darwin
+import Foundation
+import os
+
+private let helperLog = Logger(subsystem: "co.overpolish.keyframeless", category: "ai.helper")
+
+/// Entry point for the bundled `kk-ai-helper` executable: a shared, singleton
+/// child process that runs MLX local inference out-of-process for ALL clients
+/// (FxPlug plugins + the FCP workflow extension). It binds a Unix-domain socket
+/// in the app-group container; the first client to need inference spawns it, and
+/// every other client connects to the same socket - so the model loads once and
+/// serves everyone, regardless of how many plugin instances or extensions are
+/// open.
+///
+/// Lifecycle by connection count: each connected client holds its socket open
+/// for its whole process lifetime, so the count of open connections IS the live
+/// client count. When the last client disconnects (quit or crash closes its
+/// socket) and a short grace passes, the helper exits and unloads the model.
+///
+/// Protocol per connection: length-prefixed `HelperRequest` in, `HelperResponse`
+/// out (see HelperFraming), looping until the peer closes.
+public enum LocalAIHelperServer {
+	/// Runs the singleton server forever. Call from the helper executable's
+	/// `main.swift`: `import KeyframelessAI; LocalAIHelperServer.run()`. Never
+	/// returns (exits the process when idle).
+	/// Retains the latency-critical activity for the process lifetime (see run()).
+	nonisolated(unsafe) private static var activityToken: NSObjectProtocol?
+
+	public static func run() -> Never {
+		// Writes to a closed client socket must not kill us.
+		signal(SIGPIPE, SIG_IGN)
+
+		// CRITICAL for speed: this helper is a headless, "NotVisible", "not GPU
+		// managed" background process, so macOS energy-throttles it (App Nap + a
+		// low GPU performance state), crushing MLX inference to ~1 tok/s even with
+		// the GPU otherwise idle. Declare the work latency-critical so the OS runs
+		// us at full CPU+GPU performance. Hold the token for the whole lifetime.
+		activityToken = ProcessInfo.processInfo.beginActivity(
+			options: [.userInitiated, .latencyCritical, .idleSystemSleepDisabled],
+			reason: "kk-ai-helper local inference")
+		helperLog.notice("helper: began latency-critical activity (anti-throttle)")
+
+		// The spawning client (which holds the app-group entitlement) passes the
+		// socket path via `--socket <path>`, so the helper itself needs NO
+		// entitlement - it just binds the path it's handed (filesystem access to
+		// the group container is inherited from the spawner's sandbox). Fall back
+		// to resolving it directly only if the helper happens to be entitled.
+		let argv = CommandLine.arguments
+		let pathFromArg = argv.firstIndex(of: "--socket").flatMap { i in
+			i + 1 < argv.count ? argv[i + 1] : nil
+		}
+		guard let path = pathFromArg ?? LocalAIHelperSocket.sharedSocketPath() else {
+			helperLog.error("helper: no socket path (no --socket arg, no app-group); exiting")
+			exit(1)
+		}
+		guard let serverFd = LocalAIHelperSocket.serverBind(path: path) else {
+			// Another instance already owns the socket (we lost the spawn race) -
+			// that's fine, the winner serves everyone.
+			helperLog.notice(
+				"helper: socket already served; exiting (pid \(getpid(), privacy: .public))")
+			exit(0)
+		}
+		helperLog.notice(
+			"helper: listening at \(path, privacy: .public) (pid \(getpid(), privacy: .public))")
+
+		let runner = MLXLocalLLMRunner()
+		let tracker = ConnectionTracker()
+
+		// Accept loop blocks; run it on a background thread and hand the main
+		// thread to dispatchMain() so complete()'s MainActor hops are serviced.
+		let acceptThread = Thread {
+			while true {
+				guard let conn = LocalAIHelperSocket.acceptConn(serverFd) else { continue }
+				tracker.opened()
+				let worker = Thread {
+					serveConnection(conn, runner: runner)
+					tracker.closed()
+				}
+				worker.stackSize = 8 << 20
+				worker.qualityOfService = .userInitiated
+				worker.start()
+			}
+		}
+		acceptThread.stackSize = 1 << 20
+		acceptThread.start()
+		dispatchMain()
+	}
+
+	/// Start the socket server on a BACKGROUND thread and RETURN, leaving the
+	/// caller's main thread to run its own event loop. Use this from a real
+	/// **agent app** (`NSApplication`) so the process is a managed app WITH a GPU
+	/// role (the bare CLI `run()` is gpuRole:None and gets throttled). The app's
+	/// run loop services the MainActor hops inside complete(). Unlike `run()`,
+	/// this does NOT exit on idle - the app owns its lifecycle (it can unload the
+	/// model when idle later; for now the model just stays warm).
+	///
+	/// Call once, e.g. from the App's `init`:
+	///   `import KeyframelessAI; LocalAIHelperServer.startInBackground()`
+	public static func startInBackground() {
+		signal(SIGPIPE, SIG_IGN)
+
+		guard let path = LocalAIHelperSocket.sharedSocketPath() else {
+			helperLog.error("agent: no app-group socket path (entitlement?); not serving")
+			return
+		}
+		guard let serverFd = LocalAIHelperSocket.serverBind(path: path) else {
+			helperLog.notice("agent: socket already served by another instance")
+			return
+		}
+		helperLog.notice(
+			"agent: listening at \(path, privacy: .public) (pid \(getpid(), privacy: .public))")
+
+		let runner = MLXLocalLLMRunner()
+		let acceptThread = Thread {
+			while true {
+				guard let conn = LocalAIHelperSocket.acceptConn(serverFd) else { continue }
+				helperLog.notice("agent: client connected")
+				let worker = Thread {
+					serveConnection(conn, runner: runner)
+					helperLog.notice("agent: client disconnected")
+				}
+				worker.stackSize = 8 << 20
+				worker.qualityOfService = .userInitiated
+				worker.start()
+			}
+		}
+		acceptThread.stackSize = 1 << 20
+		acceptThread.qualityOfService = .userInitiated
+		acceptThread.start()
+	}
+
+	/// Serve one client connection until it closes.
+	private static func serveConnection(_ fd: Int32, runner: MLXLocalLLMRunner) {
+		let h = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+		while true {
+			let reqData: Data?
+			do {
+				reqData = try HelperFraming.read(from: h)
+			} catch {
+				break
+			}
+			guard let reqData else { break }  // clean EOF: client gone
+
+			let req: HelperRequest
+			do {
+				req = try JSONDecoder().decode(HelperRequest.self, from: reqData)
+			} catch {
+				let bad = HelperResponse(result: nil, error: "helper: bad request: \(error)")
+				if !writeFrame(bad, to: h) { break }
+				continue
+			}
+
+			// Streaming answers emit many chunk frames then a done frame; everything
+			// else is one result frame. Either path returns false on a write failure
+			// (peer closed) so we stop serving this connection.
+			let ok =
+				req.stream == true
+				? streamResponse(req, runner: runner, to: h)
+				: writeFrame(handle(req, runner: runner, to: h), to: h)
+			if !ok { break }
+		}
+		try? h.close()
+	}
+
+	private static func writeFrame(_ resp: HelperResponse, to h: FileHandle) -> Bool {
+		do {
+			try HelperFraming.write(try JSONEncoder().encode(resp), to: h)
+			return true
+		} catch {
+			return false  // peer closed mid-write
+		}
+	}
+
+	private static func handle(
+		_ req: HelperRequest, runner: MLXLocalLLMRunner, to h: FileHandle
+	) -> HelperResponse {
+		// Bridge the actor's async API to this synchronous (background-thread)
+		// loop. Safe because complete()'s MainActor hops are serviced by
+		// dispatchMain() on the main thread, not this one. The actor serialises
+		// concurrent connections' calls onto the single loaded model.
+		let sem = DispatchSemaphore(value: 0)
+		let box = ResultBox()
+		let sink = FrameSink(h)
+		Task(priority: .userInitiated) {
+			// Forward the runner's coarse status ("Loading model…"/"Thinking…") to
+			// the client as status frames, written before the terminal result frame
+			// (the runner reports them during the awaited call below).
+			await LocalRunnerStatus.$sink.withValue({ status in
+				sink.send(HelperResponse(result: nil, error: nil, status: status))
+			}) {
+				do {
+					let text = try await runner.complete(
+						modelID: req.modelID, system: req.system, user: req.user,
+						jsonSchemaJSON: req.jsonSchemaJSON, enableThinking: req.enableThinking)
+					box.value = .success(text)
+				} catch {
+					box.value = .failure(error)
+				}
+			}
+			sem.signal()
+		}
+		sem.wait()
+
+		switch box.value {
+		case .success(let text): return HelperResponse(result: text, error: nil)
+		case .failure(let err): return HelperResponse(result: nil, error: err.localizedDescription)
+		case .none: return HelperResponse(result: nil, error: "helper: no result")
+		}
+	}
+
+	/// Stream a plain-text answer: forward each chunk from the runner as its own
+	/// frame, then a `done` frame (or an `error` frame on failure). Blocks this
+	/// connection thread until the stream completes - the model is single-GPU and
+	/// serialised by the actor anyway - and only this thread writes to `h` while it
+	/// runs, so frames never interleave. Returns false if a frame write fails.
+	private static func streamResponse(
+		_ req: HelperRequest, runner: MLXLocalLLMRunner, to h: FileHandle
+	) -> Bool {
+		let sem = DispatchSemaphore(value: 0)
+		let writeOK = FlagBox()
+		let sink = FrameSink(h)
+		Task(priority: .userInitiated) {
+			func send(_ resp: HelperResponse) -> Bool {
+				let ok = writeFrame(resp, to: h)
+				if !ok { writeOK.value = false }
+				return ok
+			}
+			// Status frames ("Loading model…"/"Thinking…") precede the chunk frames,
+			// emitted by the runner during the awaited call below.
+			await LocalRunnerStatus.$sink.withValue({ status in
+				sink.send(HelperResponse(result: nil, error: nil, status: status))
+			}) {
+				do {
+					let stream = await runner.completeStreaming(
+						modelID: req.modelID, system: req.system, user: req.user)
+					for try await chunk in stream {
+						if !send(HelperResponse(result: nil, error: nil, chunk: chunk)) { break }
+					}
+					if writeOK.value {
+						_ = send(HelperResponse(result: nil, error: nil, done: true))
+					}
+				} catch {
+					_ = send(HelperResponse(result: nil, error: error.localizedDescription))
+				}
+			}
+			sem.signal()
+		}
+		sem.wait()
+		return writeOK.value
+	}
+
+	private final class ResultBox: @unchecked Sendable {
+		var value: Result<String, Error>?
+	}
+
+	private final class FlagBox: @unchecked Sendable {
+		var value = true
+	}
+
+	/// Sendable wrapper so a status frame can be written from the runner's
+	/// `@Sendable` status sink without capturing the non-Sendable FileHandle
+	/// directly. Best-effort (status is non-critical); errors are swallowed.
+	private final class FrameSink: @unchecked Sendable {
+		private let h: FileHandle
+		init(_ h: FileHandle) { self.h = h }
+		func send(_ resp: HelperResponse) {
+			guard let out = try? JSONEncoder().encode(resp) else { return }
+			try? HelperFraming.write(out, to: h)
+		}
+	}
+
+	/// Tracks open client connections and exits the process when the last one
+	/// closes (after a grace period). Also arms an initial timer so a helper that
+	/// nobody ever connects to (spawner died) doesn't linger forever.
+	private final class ConnectionTracker: @unchecked Sendable {
+		private let lock = NSLock()
+		private var count = 0
+		// Stay warm across a whole editing session so coming back to the tool
+		// doesn't re-pay the ~5s model load (and any first-time Metal-kernel
+		// compile). Only matters after the LAST client disconnects - an open
+		// plugin/extension holds its connection, keeping the helper alive
+		// regardless. The model is ~16 GB resident while warm, so this trades that
+		// memory for responsiveness; 30 min covers typical step-away gaps.
+		private let grace: TimeInterval = 1800
+		private let queue = DispatchQueue(label: "co.overpolish.ai.helper.idle")
+
+		init() {
+			armIdleCheck()  // exit if no one connects within `grace`
+		}
+
+		func opened() {
+			lock.lock()
+			count += 1
+			let c = count
+			lock.unlock()
+			helperLog.notice("helper: client connected (\(c, privacy: .public) active)")
+		}
+
+		func closed() {
+			lock.lock()
+			count -= 1
+			let c = count
+			lock.unlock()
+			helperLog.notice("helper: client disconnected (\(c, privacy: .public) active)")
+			if c <= 0 { armIdleCheck() }
+		}
+
+		private func armIdleCheck() {
+			queue.asyncAfter(deadline: .now() + grace) { [self] in
+				lock.lock()
+				let c = count
+				lock.unlock()
+				if c <= 0 {
+					helperLog.notice("helper: idle \(Int(self.grace), privacy: .public)s, exiting")
+					exit(0)
+				}
+			}
+		}
+	}
+}

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalAIHelperSocket.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalAIHelperSocket.swift
@@ -1,0 +1,141 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import Darwin
+import Foundation
+
+/// POSIX Unix-domain-socket plumbing for the SHARED local-inference helper. The
+/// helper is a singleton: the first client to need it spawns it, it binds a
+/// socket in the app-group container, and every other client (plugin or
+/// extension, in any process) connects to that same socket. One model load
+/// serves everyone.
+///
+/// The socket lives in the app-group container so all sandboxed clients can reach
+/// it; that requires the `group.co.overpolish.keyframeless` app-group
+/// entitlement on every client AND on the helper. Without the entitlement
+/// `sharedSocketPath()` returns nil and callers fall back (in-process for
+/// plugins, disabled for the extension).
+enum LocalAIHelperSocket {
+	static let appGroupID = "group.co.overpolish.keyframeless"
+	/// Short name to stay well under the 104-byte sun_path limit.
+	static let socketName = "kkai.sock"
+
+	/// Shared HuggingFace model cache ("hub") directory in the app-group
+	/// container, so EVERY client downloads to - and every spawned helper loads
+	/// from - one location. Without this, a helper spawned by a different client
+	/// (different sandbox container) doesn't find the model and re-downloads it.
+	/// Returns nil without the app-group entitlement. Matches the `HF_HUB_CACHE`
+	/// layout (the dir that holds `models--org--name`).
+	static func sharedModelCacheDir() -> URL? {
+		guard
+			let container = FileManager.default.containerURL(
+				forSecurityApplicationGroupIdentifier: appGroupID)
+		else { return nil }
+		let dir = container.appendingPathComponent("huggingface", isDirectory: true)
+			.appendingPathComponent("hub", isDirectory: true)
+		try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+		return dir
+	}
+
+	/// Absolute path of the shared socket, or nil if the app-group container
+	/// isn't available (missing entitlement) or the path would exceed sun_path.
+	static func sharedSocketPath() -> String? {
+		guard
+			let container = FileManager.default.containerURL(
+				forSecurityApplicationGroupIdentifier: appGroupID)
+		else { return nil }
+		let path = container.appendingPathComponent(socketName).path
+		// sun_path is 104 bytes on Darwin; need room for the trailing NUL.
+		guard path.utf8.count < 104 else { return nil }
+		return path
+	}
+
+	/// Bind + listen as the singleton server. Returns the listening fd, or nil if
+	/// another live server already owns the socket (lost the spawn race) or bind
+	/// failed. A stale socket file (previous helper crashed) is detected by an
+	/// unconnectable address and unlinked before rebinding.
+	static func serverBind(path: String) -> Int32? {
+		let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+		guard fd >= 0 else { return nil }
+		setNoSigpipe(fd)
+
+		if !bindPath(fd, path) {
+			if errno == EADDRINUSE {
+				// Someone is bound. Live server, or a stale socket file?
+				if let probe = clientConnect(path: path) {
+					close(probe)
+					close(fd)
+					return nil  // live server already running
+				}
+				unlink(path)  // stale; reclaim it
+				if !bindPath(fd, path) {
+					close(fd)
+					return nil
+				}
+			} else {
+				close(fd)
+				return nil
+			}
+		}
+		guard listen(fd, 16) == 0 else {
+			close(fd)
+			return nil
+		}
+		return fd
+	}
+
+	/// Accept the next client connection, or nil on error.
+	static func acceptConn(_ serverFd: Int32) -> Int32? {
+		let c = accept(serverFd, nil, nil)
+		guard c >= 0 else { return nil }
+		setNoSigpipe(c)
+		return c
+	}
+
+	/// Connect to the singleton server, or nil if nobody is listening.
+	static func clientConnect(path: String) -> Int32? {
+		let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+		guard fd >= 0 else { return nil }
+		setNoSigpipe(fd)
+		if connectPath(fd, path) { return fd }
+		close(fd)
+		return nil
+	}
+
+	private static func setNoSigpipe(_ fd: Int32) {
+		var on: Int32 = 1
+		setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
+	}
+
+	private static func bindPath(_ fd: Int32, _ path: String) -> Bool {
+		withSockaddrUn(path) { ptr, len in bind(fd, ptr, len) == 0 } ?? false
+	}
+
+	private static func connectPath(_ fd: Int32, _ path: String) -> Bool {
+		withSockaddrUn(path) { ptr, len in connect(fd, ptr, len) == 0 } ?? false
+	}
+
+	/// Build a `sockaddr_un` for `path` and run `body` with it. Returns nil if the
+	/// path doesn't fit in sun_path.
+	private static func withSockaddrUn<T>(
+		_ path: String, _ body: (UnsafePointer<sockaddr>, socklen_t) -> T
+	) -> T? {
+		var addr = sockaddr_un()
+		addr.sun_family = sa_family_t(AF_UNIX)
+		let bytes = Array(path.utf8)
+		let cap = MemoryLayout.size(ofValue: addr.sun_path)
+		guard bytes.count < cap else { return nil }
+		withUnsafeMutablePointer(to: &addr.sun_path) { raw in
+			raw.withMemoryRebound(to: UInt8.self, capacity: cap) { dst in
+				for i in 0..<bytes.count { dst[i] = bytes[i] }
+				dst[bytes.count] = 0
+			}
+		}
+		let len = socklen_t(MemoryLayout<sockaddr_un>.size)
+		return withUnsafePointer(to: &addr) {
+			$0.withMemoryRebound(to: sockaddr.self, capacity: 1) { body($0, len) }
+		}
+	}
+}

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalLLM.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalLLM.swift
@@ -25,6 +25,35 @@ public protocol LocalLLMRunner: Sendable {
 		jsonSchemaJSON: String?,
 		enableThinking: Bool
 	) async throws -> String
+
+	/// Stream a PLAIN-TEXT completion (an answer) token-by-token so the UI can
+	/// show the reply as it's written. No schema, no thinking - streaming only
+	/// makes sense for free-form answers (a structured/transform result is applied
+	/// atomically, so there's nothing to show mid-flight). Yields incremental
+	/// chunks; the consumer accumulates. Default: a single chunk via `complete`.
+	func completeStreaming(
+		modelID: String, system: String, user: String
+	) async -> AsyncThrowingStream<String, Error>
+}
+
+extension LocalLLMRunner {
+	public func completeStreaming(
+		modelID: String, system: String, user: String
+	) async -> AsyncThrowingStream<String, Error> {
+		AsyncThrowingStream { continuation in
+			Task {
+				do {
+					let text = try await complete(
+						modelID: modelID, system: system, user: user,
+						jsonSchemaJSON: nil, enableThinking: false)
+					continuation.yield(text)
+					continuation.finish()
+				} catch {
+					continuation.finish(throwing: error)
+				}
+			}
+		}
+	}
 }
 
 public enum LocalLLM {

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalLLM.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalLLM.swift
@@ -4,10 +4,14 @@
  */
 
 import Foundation
+import os
 
-/// Local inference, behind a protocol so the engine is swappable. The default is
-/// `MLXLocalLLMRunner` - Apple's MLX, in-process (no helper / XPC / launch
-/// infrastructure). Plugins need no setup.
+private let llmLog = Logger(subsystem: "co.overpolish.keyframeless", category: "ai.helper")
+
+/// Local inference, behind a protocol so the engine is swappable. Two concrete
+/// runners ship: `SharedHelperRunner` (talks to one shared out-of-process helper
+/// over an app-group socket) and `MLXLocalLLMRunner` (Apple MLX, in-process).
+/// The right one is chosen automatically - see `LocalLLM.defaultRunner`.
 public protocol LocalLLMRunner: Sendable {
 	/// Run one chat completion against the on-demand-loaded local model.
 	/// - Parameters:
@@ -57,7 +61,48 @@ extension LocalLLMRunner {
 }
 
 public enum LocalLLM {
-	/// Defaults to the in-process MLX runner. Overridable for tests / alternate
-	/// engines. Load or inference failure surfaces as a thrown error at call time.
-	@MainActor public static var runner: LocalLLMRunner? = MLXLocalLLMRunner()
+	/// The active runner. Defaults per host (see `defaultRunner`); overridable for
+	/// tests / alternate engines. `nil` means local inference is unavailable and
+	/// the `.local` dispatch throws rather than runs.
+	@MainActor public static var runner: LocalLLMRunner? = defaultRunner()
+
+	/// Name of the helper executable, embedded in each client's bundle.
+	private static let helperName = "kk-ai-helper"
+
+	/// Pick the right engine for the current host:
+	/// - If the app-group socket is reachable (the `group.co.overpolish.keyframeless`
+	///   entitlement is present), use the SHARED out-of-process helper for EVERY
+	///   client - extension AND plugins. One helper process, one model load, serving
+	///   them all: it dodges the FCP workflow extension's ~1 GB cap AND stops each
+	///   plugin XPC instance from loading its own ~16 GB copy. The first client to
+	///   call spawns it from its own bundle; the rest connect over the socket.
+	/// - Otherwise (no app-group entitlement wired yet): the memory-capped extension
+	///   can't load MLX in-process, so local is disabled (nil); a plugin has the
+	///   headroom, so it falls back to the in-process MLX runner.
+	@MainActor static func defaultRunner() -> LocalLLMRunner? {
+		if let shared = SharedHelperRunner(helperLocator: { helperBinaryURL() }) {
+			llmLog.notice("LocalLLM: shared out-of-process helper (app-group)")
+			return shared
+		}
+		guard Bundle.main.bundleURL.pathExtension == "appex" else {
+			llmLog.notice("LocalLLM: in-process MLX (plugin, no app-group)")
+			return MLXLocalLLMRunner()
+		}
+		llmLog.error("LocalLLM: extension has no app-group socket; local disabled")
+		return nil
+	}
+
+	/// The helper executable embedded in THIS client's bundle (sandbox only allows
+	/// exec'ing in-bundle binaries). Resolved via the auxiliary-executable lookup,
+	/// with a direct Contents/MacOS fallback.
+	private static func helperBinaryURL() -> URL? {
+		let fm = FileManager.default
+		if let aux = Bundle.main.url(forAuxiliaryExecutable: helperName),
+			fm.fileExists(atPath: aux.path)
+		{
+			return aux
+		}
+		let direct = Bundle.main.bundleURL.appendingPathComponent("Contents/MacOS/\(helperName)")
+		return fm.fileExists(atPath: direct.path) ? direct : nil
+	}
 }

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalLLM.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalLLM.swift
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import Foundation
+
+/// Local inference, behind a protocol so the engine is swappable. The default is
+/// `MLXLocalLLMRunner` - Apple's MLX, in-process (no helper / XPC / launch
+/// infrastructure). Plugins need no setup.
+public protocol LocalLLMRunner: Sendable {
+	/// Run one chat completion against the on-demand-loaded local model.
+	/// - Parameters:
+	///   - modelID: catalog id selecting which model to load.
+	///   - jsonSchemaJSON: the JSON Schema serialized to a string for structured
+	///     passes (grammar-constrained output); nil for free-form text. (A string
+	///     rather than `[String: Any]` so it's Sendable across the actor boundary.)
+	///   - enableThinking: set by the pipeline for complex timing/values passes;
+	///     triggers a two-pass run (reason freely, then grammar-format to JSON).
+	/// - Returns: the assistant message content (JSON string, or plain text).
+	func complete(
+		modelID: String,
+		system: String,
+		user: String,
+		jsonSchemaJSON: String?,
+		enableThinking: Bool
+	) async throws -> String
+}
+
+public enum LocalLLM {
+	/// Defaults to the in-process MLX runner. Overridable for tests / alternate
+	/// engines. Load or inference failure surfaces as a thrown error at call time.
+	@MainActor public static var runner: LocalLLMRunner? = MLXLocalLLMRunner()
+}

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalModelCatalog.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalModelCatalog.swift
@@ -35,14 +35,6 @@ public enum LocalModelCatalog {
 	/// order, and the recommendation prefers later (larger) entries when the
 	/// hardware qualifies.
 	public static let models: [LocalAIModel] = [
-		LocalAIModel(
-			id: "qwen-3.5-9b",
-			displayName: "Qwen 3.5 9B",
-			blurb: AILoc("Strong reasoning, needs 16 GB"),
-			sizeDescription: "~5 GB",
-			minRAMGB: 16,
-			repoID: "mlx-community/Qwen3.5-9B-4bit"
-		),
 		// MoE: 26B of knowledge, only 4B active per token, so it reasons like a
 		// big model at ~4B speed. The dense 12B/31B would be ideal sizes but ship
 		// as model_type "gemma4_unified", which mlx-swift-lm 3.31.3 can't load;
@@ -50,11 +42,24 @@ public enum LocalModelCatalog {
 		LocalAIModel(
 			id: "gemma-4-26b-a4b",
 			displayName: "Gemma 4 26B (A4B)",
-			blurb: AILoc("Best quality, needs 24 GB"),
+			blurb: AILoc("Fast and capable"),
 			sizeDescription: "~16 GB",
 			minRAMGB: 24,
 			repoID: "mlx-community/gemma-4-26b-a4b-it-4bit",
 			usesVLMFactory: true
+		),
+		// Qwen3 30B MoE: 30B of weights, only ~3B active per token, so it reasons
+		// like a big model at a fraction of the compute. Heaviest option (~17 GB
+		// resident, wants 32 GB) - offered for big-RAM Macs; on 24 GB it loads but
+		// isn't the recommended pick. Dense-MoE text model, loads via the standard
+		// LLM path (model_type "qwen3_moe"), not the VLM factory.
+		LocalAIModel(
+			id: "qwen3-30b-a3b",
+			displayName: "Qwen3 30B (A3B)",
+			blurb: AILoc("Smartest, heaviest"),
+			sizeDescription: "~17 GB",
+			minRAMGB: 32,
+			repoID: "mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit"
 		),
 	]
 
@@ -62,8 +67,10 @@ public enum LocalModelCatalog {
 		models.first { $0.id == id }
 	}
 
-	/// The largest model the host has the RAM for. Falls back to the first
-	/// (lightest) entry on low-memory machines.
+	/// The largest model whose RAM requirement the host meets. `minRAMGB` already
+	/// includes headroom for FCP + the OS (the ~16 GB Gemma MoE wants a 24 GB Mac),
+	/// and the buffer-cache cap (see MLXLocalLLMRunner) keeps the footprint from
+	/// ballooning into swap. Falls back to the lightest entry.
 	public static var recommendedModelID: String {
 		let ramGB = Int(ProcessInfo.processInfo.physicalMemory / 1_073_741_824)
 		let affordable = models.filter { ramGB >= $0.minRAMGB }

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalModelCatalog.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalModelCatalog.swift
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import Foundation
+
+/// One downloadable local model. The catalog is a plain array of these, so
+/// adding a model later is a one-line append - no other code needs to change.
+/// `minRAMGB` drives the hardware-based "Recommended" badge (mirrors Steno's
+/// `recommendedModelId` heuristic): the largest model whose RAM floor the host
+/// meets is the recommendation.
+public struct LocalAIModel: Identifiable, Sendable {
+	public let id: String
+	public let displayName: String
+	/// One-line blurb shown under the name (the "blurb under each" the design
+	/// calls for). Keep it to a single sentence.
+	public let blurb: String
+	public let sizeDescription: String
+	/// Rough resident RAM at this quantization, used for the recommendation
+	/// heuristic only - not a hard gate.
+	public let minRAMGB: Int
+	/// HuggingFace repo id of the MLX (safetensors) model, e.g.
+	/// `mlx-community/...-4bit`. MLX/Hub downloads + caches this on first load.
+	public let repoID: String
+	/// MoE / multimodal Gemma 4 checkpoints (e.g. 26B-A4B) must load through
+	/// mlx's VLM factory - the LLM factory's dense Gemma4TextModel silently drops
+	/// the expert/router weights. Dense text models (Qwen, Gemma 4 E4B) load via
+	/// the default LLM path. Defaults to false.
+	public var usesVLMFactory: Bool = false
+}
+
+public enum LocalModelCatalog {
+	/// The shipping catalog. Order matters: rows render top-to-bottom in this
+	/// order, and the recommendation prefers later (larger) entries when the
+	/// hardware qualifies.
+	public static let models: [LocalAIModel] = [
+		LocalAIModel(
+			id: "qwen-3.5-9b",
+			displayName: "Qwen 3.5 9B",
+			blurb: AILoc("Strong reasoning, needs 16 GB"),
+			sizeDescription: "~5 GB",
+			minRAMGB: 16,
+			repoID: "mlx-community/Qwen3.5-9B-4bit"
+		),
+		// MoE: 26B of knowledge, only 4B active per token, so it reasons like a
+		// big model at ~4B speed. The dense 12B/31B would be ideal sizes but ship
+		// as model_type "gemma4_unified", which mlx-swift-lm 3.31.3 can't load;
+		// this A4B variant is "gemma4" and loads via the same text path as E4B.
+		LocalAIModel(
+			id: "gemma-4-26b-a4b",
+			displayName: "Gemma 4 26B (A4B)",
+			blurb: AILoc("Best quality, needs 24 GB"),
+			sizeDescription: "~16 GB",
+			minRAMGB: 24,
+			repoID: "mlx-community/gemma-4-26b-a4b-it-4bit",
+			usesVLMFactory: true
+		),
+	]
+
+	public static func model(id: String) -> LocalAIModel? {
+		models.first { $0.id == id }
+	}
+
+	/// The largest model the host has the RAM for. Falls back to the first
+	/// (lightest) entry on low-memory machines.
+	public static var recommendedModelID: String {
+		let ramGB = Int(ProcessInfo.processInfo.physicalMemory / 1_073_741_824)
+		let affordable = models.filter { ramGB >= $0.minRAMGB }
+		return affordable.max(by: { $0.minRAMGB < $1.minRAMGB })?.id ?? models.first!.id
+	}
+}

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalModelStore.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalModelStore.swift
@@ -1,0 +1,221 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import Combine
+import Foundation
+import HuggingFace
+import MLXHuggingFace
+import MLXLMCommon
+import Tokenizers
+import os
+
+/// Download progress diagnostics; view in Console.app, subsystem
+/// `com.overpolish.keyframeless`, category `ai.local`.
+private let storeLog = Logger(subsystem: "com.overpolish.keyframeless", category: "ai.local")
+
+/// Tracks which local models are downloaded + which is selected. With MLX, the
+/// model is a HuggingFace repo that MLX/Hub downloads and caches on demand, so
+/// "download" just pre-fetches it and we record the installed set in
+/// UserDefaults (the Hub owns the bytes on disk).
+@MainActor
+public final class LocalModelStore: ObservableObject {
+	public static let shared = LocalModelStore()
+
+	@Published public private(set) var downloadedModels: Set<String> = []
+	@Published public private(set) var downloadingModel: String? = nil
+	@Published public private(set) var downloadProgress: Double = 0
+	/// Last download/load error, surfaced in the UI. Temporary diagnostic until
+	/// local is confirmed working end to end.
+	@Published public private(set) var lastError: String? = nil
+	@Published public var selectedModelID: String? {
+		didSet {
+			UserDefaults.standard.set(selectedModelID, forKey: Self.selectedKey)
+			// Deferred so it never runs synchronously during init (which would
+			// re-enter AIKeyState.shared while it is still being constructed).
+			Task { @MainActor in AIKeyState.shared.refresh() }
+		}
+	}
+
+	/// The local provider counts as "configured" once a model is downloaded and
+	/// selected - the equivalent of having a saved API key.
+	public var hasReadyModel: Bool {
+		guard let id = selectedModelID else { return false }
+		return downloadedModels.contains(id)
+	}
+
+	/// Total bytes for the active download, learned from the Hub progress handler;
+	/// the on-disk poll divides by this to compute the real fraction.
+	private var downloadTotalBytes: Int64 = 0
+
+	private static let selectedKey = "com.overpolish.ai.local.selectedModel"
+	private static let downloadedKey = "com.overpolish.ai.local.downloadedModels"
+
+	private init() {
+		let saved = Set(UserDefaults.standard.stringArray(forKey: Self.downloadedKey) ?? [])
+		// Only trust entries still in the catalog.
+		let valid = Set(LocalModelCatalog.models.map(\.id))
+		downloadedModels = saved.intersection(valid)
+		selectedModelID = UserDefaults.standard.string(forKey: Self.selectedKey)
+		if let current = selectedModelID, !downloadedModels.contains(current) {
+			selectedModelID = downloadedModels.first
+		} else if selectedModelID == nil {
+			selectedModelID = downloadedModels.first
+		}
+	}
+
+	public func refreshDownloaded() {
+		// Source of truth is our persisted set; MLX/Hub owns the actual cache.
+		let valid = Set(LocalModelCatalog.models.map(\.id))
+		downloadedModels = downloadedModels.intersection(valid)
+	}
+
+	/// Pre-fetch (and cache) the model files via HuggingFace Hub. We download the
+	/// snapshot directly rather than going through `loadModelContainer` - the
+	/// latter loads the whole model (up to ~16 GB) into memory just to discard
+	/// it, which is wasteful and reports no progress during the load phase. The
+	/// bytes land in the Hub cache, so the runner's later load is a cache hit.
+	public func download(_ id: String) async {
+		guard downloadingModel == nil, let model = LocalModelCatalog.model(id: id) else { return }
+		guard let repo = Repo.ID(rawValue: model.repoID) else {
+			lastError = "\(model.repoID): invalid repository id"
+			return
+		}
+		downloadingModel = id
+		downloadProgress = 0
+		downloadTotalBytes = 0
+		lastError = nil
+
+		// swift-huggingface only bumps its Progress counter when each large shard
+		// FINISHES (bytes stream to CFNetworkDownload_*.tmp meanwhile), so its bar
+		// sits at the metadata size then jumps. Poll real bytes on disk instead:
+		// completed shards live in the repo's blobs/, in-flight ones in the temp
+		// dir. The HuggingFace Progress handler is used only to learn the total.
+		let blobsDir = Self.repoCacheDir(model.repoID).appendingPathComponent("blobs")
+		let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
+		// Ignore CFNetworkDownload temp files left over from earlier (interrupted)
+		// downloads - counting those orphans pinned the bar at 99%. Only new temp
+		// files created for THIS download count toward in-flight bytes.
+		let baselineTemps = Self.tempDownloadNames(tmpDir)
+		let poll = Task.detached { [weak self] in
+			while !Task.isCancelled {
+				let bytes =
+					Self.directorySize(blobsDir)
+					+ Self.tempDownloadSize(tmpDir, excluding: baselineTemps)
+				await MainActor.run { [weak self] in
+					guard let self, self.downloadTotalBytes > 0 else { return }
+					self.downloadProgress = min(
+						0.99, Double(bytes) / Double(self.downloadTotalBytes))
+				}
+				try? await Task.sleep(for: .milliseconds(750))
+			}
+		}
+
+		do {
+			let hub = HubClient()
+			_ = try await hub.downloadSnapshot(of: repo) { @MainActor [weak self] progress in
+				self?.downloadTotalBytes = progress.totalUnitCount
+			}
+			poll.cancel()
+			downloadProgress = 1.0
+			downloadedModels.insert(id)
+			persistDownloaded()
+			lastError = nil
+			if selectedModelID == nil { selectedModelID = id }
+		} catch {
+			poll.cancel()
+			lastError = "\(model.repoID): \(error.localizedDescription)"
+			storeLog.error(
+				"download failed \(model.repoID, privacy: .public): \(error.localizedDescription, privacy: .public)"
+			)
+		}
+		downloadingModel = nil
+	}
+
+	/// Soft cancel - resets the UI. MLX's load has no cancellation handle, so an
+	/// in-flight fetch may continue in the background.
+	public func cancelDownload() {
+		downloadingModel = nil
+		downloadProgress = 0
+	}
+
+	public func uninstall(_ id: String) {
+		downloadedModels.remove(id)
+		persistDownloaded()
+		if selectedModelID == id { selectedModelID = downloadedModels.first }
+		// Actually free the disk: delete the repo's Hub cache dir (blobs +
+		// snapshots + refs). Without this an "uninstall" only forgot the entry
+		// and a re-download finished instantly from the still-present cache.
+		guard let model = LocalModelCatalog.model(id: id) else { return }
+		let dir = Self.repoCacheDir(model.repoID)
+		do {
+			try FileManager.default.removeItem(at: dir)
+			storeLog.notice("uninstalled \(model.repoID, privacy: .public) (removed cache)")
+		} catch {
+			storeLog.error(
+				"uninstall: failed to remove \(dir.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+			)
+		}
+	}
+
+	public func select(_ id: String) {
+		guard downloadedModels.contains(id) else { return }
+		selectedModelID = id
+	}
+
+	private func persistDownloaded() {
+		UserDefaults.standard.set(Array(downloadedModels), forKey: Self.downloadedKey)
+	}
+
+	/// The HuggingFace Hub cache directory for a repo, e.g.
+	/// `<cache>/models--mlx-community--gemma-4-26b-a4b-it-4bit`.
+	private static func repoCacheDir(_ repoID: String) -> URL {
+		let dirName = "models--" + repoID.replacingOccurrences(of: "/", with: "--")
+		return HubCache.default.cacheDirectory.appendingPathComponent(dirName)
+	}
+
+	/// Total byte size of all files under `dir` (0 if it doesn't exist yet).
+	nonisolated private static func directorySize(_ dir: URL) -> Int64 {
+		let fm = FileManager.default
+		guard let en = fm.enumerator(at: dir, includingPropertiesForKeys: [.fileSizeKey]) else {
+			return 0
+		}
+		var total: Int64 = 0
+		for case let url as URL in en {
+			total += Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+		}
+		return total
+	}
+
+	/// Names of existing `CFNetworkDownload_*.tmp` files - captured at download
+	/// start so orphans from earlier attempts can be excluded from the byte count.
+	nonisolated private static func tempDownloadNames(_ tmpDir: URL) -> Set<String> {
+		let fm = FileManager.default
+		guard let items = try? fm.contentsOfDirectory(at: tmpDir, includingPropertiesForKeys: nil)
+		else { return [] }
+		return Set(
+			items.map { $0.lastPathComponent }.filter { $0.hasPrefix("CFNetworkDownload") })
+	}
+
+	/// Total bytes of in-flight URLSession downloads (`CFNetworkDownload_*.tmp`)
+	/// in the temp dir - the shards stream here before being moved into blobs/.
+	/// `excluding` skips orphan temp files from earlier download attempts.
+	nonisolated private static func tempDownloadSize(
+		_ tmpDir: URL, excluding: Set<String>
+	) -> Int64 {
+		let fm = FileManager.default
+		guard
+			let items = try? fm.contentsOfDirectory(
+				at: tmpDir, includingPropertiesForKeys: [.fileSizeKey])
+		else { return 0 }
+		var total: Int64 = 0
+		for url in items
+		where url.lastPathComponent.hasPrefix("CFNetworkDownload")
+			&& !excluding.contains(url.lastPathComponent)
+		{
+			total += Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+		}
+		return total
+	}
+}

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalModelStore.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalModelStore.swift
@@ -12,8 +12,8 @@ import Tokenizers
 import os
 
 /// Download progress diagnostics; view in Console.app, subsystem
-/// `com.overpolish.keyframeless`, category `ai.local`.
-private let storeLog = Logger(subsystem: "com.overpolish.keyframeless", category: "ai.local")
+/// `co.overpolish.keyframeless`, category `ai.local`.
+private let storeLog = Logger(subsystem: "co.overpolish.keyframeless", category: "ai.local")
 
 /// Tracks which local models are downloaded + which is selected. With MLX, the
 /// model is a HuggingFace repo that MLX/Hub downloads and caches on demand, so
@@ -49,8 +49,8 @@ public final class LocalModelStore: ObservableObject {
 	/// the on-disk poll divides by this to compute the real fraction.
 	private var downloadTotalBytes: Int64 = 0
 
-	private static let selectedKey = "com.overpolish.ai.local.selectedModel"
-	private static let downloadedKey = "com.overpolish.ai.local.downloadedModels"
+	private static let selectedKey = "co.overpolish.ai.local.selectedModel"
+	private static let downloadedKey = "co.overpolish.ai.local.downloadedModels"
 
 	private init() {
 		let saved = Set(UserDefaults.standard.stringArray(forKey: Self.downloadedKey) ?? [])
@@ -113,7 +113,7 @@ public final class LocalModelStore: ObservableObject {
 		}
 
 		do {
-			let hub = HubClient()
+			let hub = HubClient(cache: Self.sharedHubCache())
 			_ = try await hub.downloadSnapshot(of: repo) { @MainActor [weak self] progress in
 				self?.downloadTotalBytes = progress.totalUnitCount
 			}
@@ -168,11 +168,22 @@ public final class LocalModelStore: ObservableObject {
 		UserDefaults.standard.set(Array(downloadedModels), forKey: Self.downloadedKey)
 	}
 
+	/// The shared cache used for downloads. When the app-group container is
+	/// available, downloads land in the shared cache so any client's spawned
+	/// helper finds the model (no re-download); otherwise the default cache.
+	static func sharedHubCache() -> HubCache {
+		if let dir = LocalAIHelperSocket.sharedModelCacheDir() {
+			return HubCache(cacheDirectory: dir)
+		}
+		return .default
+	}
+
 	/// The HuggingFace Hub cache directory for a repo, e.g.
 	/// `<cache>/models--mlx-community--gemma-4-26b-a4b-it-4bit`.
 	private static func repoCacheDir(_ repoID: String) -> URL {
 		let dirName = "models--" + repoID.replacingOccurrences(of: "/", with: "--")
-		return HubCache.default.cacheDirectory.appendingPathComponent(dirName)
+		let base = LocalAIHelperSocket.sharedModelCacheDir() ?? HubCache.default.cacheDirectory
+		return base.appendingPathComponent(dirName)
 	}
 
 	/// Total byte size of all files under `dir` (0 if it doesn't exist yet).

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalRunnerStatus.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/LocalRunnerStatus.swift
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import Foundation
+
+/// Indirection for the runner's coarse status updates ("Loading model…",
+/// "Thinking…"). In-process the runner writes them straight to the client's
+/// `AIDraftState`, so the inspector shows what's actually happening.
+///
+/// Out-of-process the runner executes inside the `kk-ai-helper` CHILD, whose
+/// `AIDraftState` no UI observes - so the status would never reach the plugin and
+/// it'd sit on the pipeline's generic "Reading prompt…". The helper fixes this by
+/// installing a `sink` (via the task-local) around the runner call that forwards
+/// each update to the client as a status frame; the client then writes ITS OWN
+/// `AIDraftState`. Leave the sink nil for the default in-process behaviour.
+enum LocalRunnerStatus {
+	/// When set, status goes here instead of `AIDraftState` (the helper forwards
+	/// it over the socket). Task-local so it's scoped to one request and inherited
+	/// by the runner's async work, including across its `MainActor` hops.
+	@TaskLocal static var sink: (@Sendable (String) -> Void)?
+
+	/// Report a coarse status. Routes to the task-local sink when present (helper),
+	/// else to the in-process `AIDraftState` on the main actor.
+	static func report(_ status: String) async {
+		if let sink {
+			sink(status)
+		} else {
+			await MainActor.run { AIDraftState.shared.routingStatus = status }
+		}
+	}
+}

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/MLXLocalLLMRunner.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/MLXLocalLLMRunner.swift
@@ -1,0 +1,209 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import Foundation
+import HuggingFace
+import MLXHuggingFace
+import MLXLLM
+import MLXLMCommon
+import MLXVLM
+import Tokenizers
+import os
+
+/// Timing log for local inference. Lands in the unified log; view in Console.app
+/// by filtering subsystem `com.overpolish.keyframeless` category `ai.local`
+/// (the plugin runs as an XPC process, so also filter by that process name).
+private let localLog = Logger(subsystem: "com.overpolish.keyframeless", category: "ai.local")
+
+/// In-process local inference via Apple's MLX. Loads the model once (cached
+/// across calls) and runs entirely inside the calling process - no helper, no
+/// XPC, no launch infrastructure. MLX keeps weights in Metal/IOGPU buffers,
+/// which is why this survives the FxPlug XPC memory budget.
+///
+/// Structured passes use MLX's native tool-calling: the schema is registered as
+/// a single forced "tool", and we read back the parsed `ToolCall` arguments.
+/// Tool-call-trained models (Gemma, Qwen3) emit these reliably; a parse miss is
+/// retried once before erroring. This replaced XGrammar (mlx-swift-structured),
+/// which capped mlx-swift-lm at <3.0.0 and blocked the Gemma 4 / 3.x bump.
+public actor MLXLocalLLMRunner: LocalLLMRunner {
+	enum RunnerError: LocalizedError {
+		case unknownModel(String)
+		case badJSON(String)
+		var errorDescription: String? {
+			switch self {
+			case .unknownModel(let id): return "Unknown local model: \(id)"
+			case .badJSON(let raw): return "Local model didn't return JSON. Raw: \(raw)"
+			}
+		}
+	}
+
+	private var container: ModelContainer?
+	private var loadedRepoID: String?
+
+	public init() {}
+
+	public func complete(
+		modelID: String, system: String, user: String, jsonSchemaJSON: String?,
+		enableThinking: Bool
+	) async throws -> String {
+		guard let model = LocalModelCatalog.model(id: modelID) else {
+			throw RunnerError.unknownModel(modelID)
+		}
+		localLog.notice(
+			"complete start model=\(modelID, privacy: .public) schema=\(jsonSchemaJSON != nil, privacy: .public) thinking=\(enableThinking, privacy: .public)"
+		)
+		let loadStart = Date()
+		let container = try await loadContainer(model: model)
+		localLog.notice("load done in \(Self.ms(loadStart), privacy: .public)ms")
+
+		// On-device generation is slow enough that the pipeline's cloud-oriented
+		// per-pass label (e.g. "Reading prompt…") sits frozen for a minute, which
+		// reads as a hang. Replace it with an honest "Thinking…" once the model is
+		// actually generating. Only the local path hits this; cloud keeps its
+		// granular labels (its passes are fast HTTP calls).
+		await MainActor.run { AIDraftState.shared.routingStatus = AILoc("Thinking…") }
+
+		// Qwen3 non-thinking recommended sampling (temp 0.7 / top_p 0.8 / top_k 20).
+		// NOT greedy/low-temp - Qwen warns that degrades quality + repeats. The
+		// grammar guarantees JSON shape, so sampling only affects content quality.
+		let params = GenerateParameters(maxTokens: 4096, temperature: 0.7, topP: 0.8, topK: 20)
+
+		// Plain text (no schema): ChatSession is fine.
+		guard let schemaString = jsonSchemaJSON else {
+			let session = ChatSession(
+				container,
+				instructions: system,
+				generateParameters: params,
+				additionalContext: ["enable_thinking": false]
+			)
+			let genStart = Date()
+			let text = Self.stripThink(try await session.respond(to: user))
+			localLog.notice("text gen done in \(Self.ms(genStart), privacy: .public)ms")
+			return text
+		}
+
+		// Two-pass for reasoning-heavy passes: grammar-constrained JSON leaves no
+		// room for <think> tokens, so let the model reason FREELY first (pass 1),
+		// then fold that analysis into the grammar-constrained JSON (pass 2). Single
+		// pass for simple structured calls (classify/styles) to avoid the 2x cost.
+		// The thinking budget is capped hard: routing/timing reasoning fits in a few
+		// hundred tokens, and an uncapped budget lets Qwen3 ramble for thousands of
+		// tokens - the difference between a snappy answer and a minute-long stall.
+		var formatSystem = system
+		if enableThinking {
+			// Qwen3 thinking-mode recommended sampling.
+			let thinkParams = GenerateParameters(
+				maxTokens: 1024, temperature: 0.6, topP: 0.95, topK: 20)
+			let thinker = ChatSession(
+				container,
+				instructions: system,
+				generateParameters: thinkParams,
+				additionalContext: ["enable_thinking": true]
+			)
+			let thinkStart = Date()
+			let analysis = Self.stripThink(try await thinker.respond(to: user))
+			localLog.notice("think pass done in \(Self.ms(thinkStart), privacy: .public)ms")
+			formatSystem =
+				system + "\n\nThe request was analysed as follows:\n\(analysis)"
+				+ "\n\nNow return the result by calling the function."
+		}
+
+		// Structured pass: prompt for raw JSON with the schema in the system
+		// prompt, then extract the {...} from the reply. We deliberately do NOT
+		// use mlx's tool-calling: its inline ToolCallProcessor buffers anything
+		// starting with `{` expecting a {name,arguments} envelope and SWALLOWS a
+		// bare result object (never emitted as a chunk OR parsed as a tool call).
+		// Retry once on a miss; the raw output is logged/surfaced for diagnosis.
+		let fmtStart = Date()
+		var result = try await Self.generateStructured(
+			container: container, system: formatSystem, user: user,
+			schemaString: schemaString, params: params)
+		if result.json == nil {
+			localLog.notice(
+				"format pass: no JSON. rawLen=\(result.raw.count, privacy: .public) raw=\(result.raw.prefix(500), privacy: .public)"
+			)
+			result = try await Self.generateStructured(
+				container: container, system: formatSystem, user: user,
+				schemaString: schemaString, params: params)
+		}
+		localLog.notice("format pass done in \(Self.ms(fmtStart), privacy: .public)ms")
+		guard let json = result.json else {
+			throw RunnerError.badJSON(String(result.raw.prefix(400)))
+		}
+		return json
+	}
+
+	private struct StructuredResult {
+		let json: String?
+		let raw: String
+	}
+
+	/// Structured generation by prompting for a raw JSON object (schema embedded
+	/// in the system prompt) and extracting the outermost {...} from the reply.
+	/// Returns the raw text too so callers can diagnose a parse miss.
+	private static func generateStructured(
+		container: ModelContainer, system: String, user: String,
+		schemaString: String, params: GenerateParameters
+	) async throws -> StructuredResult {
+		let jsonSystem =
+			system + "\n\n"
+			+ "Respond with ONLY a single JSON object conforming to this JSON Schema. "
+			+ "No prose, no explanation, no markdown code fences - just the raw JSON.\n\n"
+			+ "JSON Schema:\n\(schemaString)"
+		let session = ChatSession(
+			container,
+			instructions: jsonSystem,
+			generateParameters: params,
+			additionalContext: ["enable_thinking": false]
+		)
+		let text = Self.stripThink(try await session.respond(to: user))
+		return StructuredResult(json: Self.extractJSONObject(from: text), raw: text)
+	}
+
+	/// Best-effort: return the substring from the first `{` to the last `}` if
+	/// it parses as a JSON object, else nil.
+	private static func extractJSONObject(from s: String) -> String? {
+		guard let open = s.firstIndex(of: "{"), let close = s.lastIndex(of: "}"),
+			open < close
+		else { return nil }
+		let candidate = String(s[open...close])
+		guard let data = candidate.data(using: .utf8),
+			(try? JSONSerialization.jsonObject(with: data)) is [String: Any]
+		else { return nil }
+		return candidate
+	}
+
+	private func loadContainer(model: LocalAIModel) async throws -> ModelContainer {
+		if let container, loadedRepoID == model.repoID { return container }
+		await MainActor.run { AIDraftState.shared.routingStatus = AILoc("Loading model…") }
+		// MoE/multimodal Gemma 4 must go through the VLM factory (its MoE blocks
+		// live there); dense text models use the default LLM loader.
+		let loaded: ModelContainer
+		if model.usesVLMFactory {
+			loaded = try await VLMModelFactory.shared.loadContainer(
+				from: #hubDownloader(), using: #huggingFaceTokenizerLoader(),
+				configuration: ModelConfiguration(id: model.repoID))
+		} else {
+			loaded = try await loadModelContainer(
+				from: #hubDownloader(), using: #huggingFaceTokenizerLoader(), id: model.repoID)
+		}
+		container = loaded
+		loadedRepoID = model.repoID
+		return loaded
+	}
+
+	/// Elapsed milliseconds since `start`, rounded, for timing logs.
+	private static func ms(_ start: Date) -> Int {
+		Int((Date().timeIntervalSince(start) * 1000).rounded())
+	}
+
+	/// Drop a leading `<think>…</think>` block if a model emitted one anyway.
+	static func stripThink(_ s: String) -> String {
+		guard let r = s.range(of: "</think>") else {
+			return s.trimmingCharacters(in: .whitespacesAndNewlines)
+		}
+		return String(s[r.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+	}
+}

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/MLXLocalLLMRunner.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/MLXLocalLLMRunner.swift
@@ -14,9 +14,9 @@ import Tokenizers
 import os
 
 /// Timing log for local inference. Lands in the unified log; view in Console.app
-/// by filtering subsystem `com.overpolish.keyframeless` category `ai.local`
+/// by filtering subsystem `co.overpolish.keyframeless` category `ai.local`
 /// (the plugin runs as an XPC process, so also filter by that process name).
-private let localLog = Logger(subsystem: "com.overpolish.keyframeless", category: "ai.local")
+private let localLog = Logger(subsystem: "co.overpolish.keyframeless", category: "ai.local")
 
 /// In-process local inference via Apple's MLX. Loads the model once (cached
 /// across calls) and runs entirely inside the calling process - no helper, no
@@ -92,7 +92,7 @@ public actor MLXLocalLLMRunner: LocalLLMRunner {
 		// reads as a hang. Replace it with an honest "Thinking…" once the model is
 		// actually generating. Only the local path hits this; cloud keeps its
 		// granular labels (its passes are fast HTTP calls).
-		await MainActor.run { AIDraftState.shared.routingStatus = AILoc("Thinking…") }
+		await LocalRunnerStatus.report(AILoc("Thinking"))
 
 		// Qwen3 non-thinking recommended sampling (temp 0.7 / top_p 0.8 / top_k 20).
 		// NOT greedy/low-temp - Qwen warns that degrades quality + repeats. The
@@ -180,7 +180,7 @@ public actor MLXLocalLLMRunner: LocalLLMRunner {
 						throw RunnerError.unknownModel(modelID)
 					}
 					let container = try await loadContainer(model: model)
-					await MainActor.run { AIDraftState.shared.routingStatus = AILoc("Thinking…") }
+					await LocalRunnerStatus.report(AILoc("Thinking"))
 					let params = GenerateParameters(
 						maxTokens: 4096, temperature: 0.7, topP: 0.8, topK: 20)
 					let session = ChatSession(
@@ -242,21 +242,37 @@ public actor MLXLocalLLMRunner: LocalLLMRunner {
 
 	private func loadContainer(model: LocalAIModel) async throws -> ModelContainer {
 		if let container, loadedRepoID == model.repoID { return container }
-		await MainActor.run { AIDraftState.shared.routingStatus = AILoc("Loading model…") }
+		await LocalRunnerStatus.report(AILoc("Loading model"))
 		// MoE/multimodal Gemma 4 must go through the VLM factory (its MoE blocks
 		// live there); dense text models use the default LLM loader.
 		let loaded: ModelContainer
+		let hub = Self.hubClient()
 		if model.usesVLMFactory {
 			loaded = try await VLMModelFactory.shared.loadContainer(
-				from: #hubDownloader(), using: #huggingFaceTokenizerLoader(),
+				from: #hubDownloader(hub), using: #huggingFaceTokenizerLoader(),
 				configuration: ModelConfiguration(id: model.repoID))
 		} else {
 			loaded = try await loadModelContainer(
-				from: #hubDownloader(), using: #huggingFaceTokenizerLoader(), id: model.repoID)
+				from: #hubDownloader(hub), using: #huggingFaceTokenizerLoader(), id: model.repoID)
 		}
 		container = loaded
 		loadedRepoID = model.repoID
 		return loaded
+	}
+
+	/// HubClient that loads from the SHARED app-group model cache so the host app
+	/// and the spawned helper find the model the clients downloaded - never
+	/// re-downloading. The host resolves the group container directly (it's
+	/// entitled); the spawned helper (which may not be) reads the `HF_HUB_CACHE`
+	/// the parent passed. Falls back to the default cache (e.g. in-process plugins).
+	private static func hubClient() -> HubClient {
+		if let dir = LocalAIHelperSocket.sharedModelCacheDir() {
+			return HubClient(cache: HubCache(cacheDirectory: dir))
+		}
+		if let env = ProcessInfo.processInfo.environment["HF_HUB_CACHE"], !env.isEmpty {
+			return HubClient(cache: HubCache(cacheDirectory: URL(fileURLWithPath: env)))
+		}
+		return HubClient()
 	}
 
 	/// Elapsed milliseconds since `start`, rounded, for timing logs.

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/MLXLocalLLMRunner.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/MLXLocalLLMRunner.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import HuggingFace
+import MLX
 import MLXHuggingFace
 import MLXLLM
 import MLXLMCommon
@@ -42,7 +43,35 @@ public actor MLXLocalLLMRunner: LocalLLMRunner {
 	private var container: ModelContainer?
 	private var loadedRepoID: String?
 
-	public init() {}
+	/// A local "think" pass (reason freely, then grammar-format) roughly DOUBLES
+	/// each structured step - and verbose models (Qwen3 especially) ramble to the
+	/// token cap, so the reasoning pass alone can run ~50s on a 9B. Off by default:
+	/// one-shot structured output is usually fine and keeps the pipeline snappy.
+	/// Flip to true to trade speed for quality on hard prompts.
+	nonisolated(unsafe) static var thinkingEnabled = false
+
+	public init() {
+		Self.capCacheOnce()
+	}
+
+	/// MLX's buffer cache defaults to the FULL memory limit (~1.5x the device
+	/// working set), so during inference it accumulates many GB of freed-but-
+	/// retained buffers - a 4-bit 9B whose WEIGHTS are ~5 GB balloons to ~15 GB
+	/// resident (measured), which on a 24 GB unified-memory Mac (shared with FCP)
+	/// forces swap and was the cause of the swapping/thrash. Cap it to keep the
+	/// footprint near the live model size. Measured: 512 MB vs 2 GB made NO
+	/// difference to prefill/decode speed here, so we take the smaller footprint.
+	/// Only bounds RETAINED freed buffers, not live allocations; `memoryLimit`
+	/// untouched.
+	nonisolated(unsafe) private static var cacheCapped = false
+	private static func capCacheOnce() {
+		guard !cacheCapped else { return }
+		cacheCapped = true
+		let before = MLX.Memory.cacheLimit
+		MLX.Memory.cacheLimit = 512 * 1024 * 1024
+		localLog.notice(
+			"GPU cacheLimit \(before, privacy: .public) -> 512MB (bound footprint, avoid swap)")
+	}
 
 	public func complete(
 		modelID: String, system: String, user: String, jsonSchemaJSON: String?,
@@ -92,10 +121,12 @@ public actor MLXLocalLLMRunner: LocalLLMRunner {
 		// hundred tokens, and an uncapped budget lets Qwen3 ramble for thousands of
 		// tokens - the difference between a snappy answer and a minute-long stall.
 		var formatSystem = system
-		if enableThinking {
-			// Qwen3 thinking-mode recommended sampling.
+		if enableThinking && Self.thinkingEnabled {
+			// Qwen3 thinking-mode recommended sampling. Budget capped HARD at 384:
+			// routing/timing reasoning fits in a couple hundred tokens, and Qwen3
+			// otherwise rambles straight to the cap (1024 tok ≈ 50s on a 9B).
 			let thinkParams = GenerateParameters(
-				maxTokens: 1024, temperature: 0.6, topP: 0.95, topK: 20)
+				maxTokens: 384, temperature: 0.6, topP: 0.95, topK: 20)
 			let thinker = ChatSession(
 				container,
 				instructions: system,
@@ -133,6 +164,40 @@ public actor MLXLocalLLMRunner: LocalLLMRunner {
 			throw RunnerError.badJSON(String(result.raw.prefix(400)))
 		}
 		return json
+	}
+
+	/// Token-by-token plain-text generation for the answer path. Same setup as the
+	/// no-schema branch of `complete`, but yields each chunk as it's produced so
+	/// the popover can render the reply live (decode is ~30 tok/s, so a multi-
+	/// second answer appears as it's written instead of all at once at the end).
+	public func completeStreaming(
+		modelID: String, system: String, user: String
+	) async -> AsyncThrowingStream<String, Error> {
+		AsyncThrowingStream { continuation in
+			let task = Task {
+				do {
+					guard let model = LocalModelCatalog.model(id: modelID) else {
+						throw RunnerError.unknownModel(modelID)
+					}
+					let container = try await loadContainer(model: model)
+					await MainActor.run { AIDraftState.shared.routingStatus = AILoc("Thinking…") }
+					let params = GenerateParameters(
+						maxTokens: 4096, temperature: 0.7, topP: 0.8, topK: 20)
+					let session = ChatSession(
+						container, instructions: system, generateParameters: params,
+						additionalContext: ["enable_thinking": false])
+					for try await chunk in session.streamResponse(
+						to: user, images: [], videos: [])
+					{
+						continuation.yield(chunk)
+					}
+					continuation.finish()
+				} catch {
+					continuation.finish(throwing: error)
+				}
+			}
+			continuation.onTermination = { _ in task.cancel() }
+		}
 	}
 
 	private struct StructuredResult {

--- a/KeyframelessAI/Sources/KeyframelessAI/Providers/SharedHelperRunner.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/Providers/SharedHelperRunner.swift
@@ -1,0 +1,258 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import Darwin
+import Foundation
+import os
+
+private let clientLog = Logger(subsystem: "co.overpolish.keyframeless", category: "ai.helper")
+
+/// `LocalLLMRunner` that talks to the SHARED out-of-process helper over a
+/// Unix-domain socket in the app-group container. Used by every memory-capped or
+/// multi-instance client (the FCP workflow extension and FxPlug plugins) so a
+/// single helper process - one model load - serves all of them.
+///
+/// First use connects to the socket; if nobody is listening it spawns the helper
+/// (from the client's own bundle, which the sandbox permits) and waits for it to
+/// come up. The connection is then held open for the client's whole lifetime:
+/// the helper counts open connections as live clients, and shuts down when the
+/// last one closes. If the helper idle-exits between requests, the next call
+/// transparently reconnects/respawns.
+///
+/// Requests are serialised on a private queue (one model, one GPU - concurrency
+/// wouldn't parallelise, and it keeps the single socket coherent).
+public final class SharedHelperRunner: LocalLLMRunner, @unchecked Sendable {
+	public enum HelperError: LocalizedError {
+		case spawnFailed(String)
+		case notConnected
+		case helperExited
+		case helperError(String)
+		public var errorDescription: String? {
+			switch self {
+			case .spawnFailed(let m): return "Couldn't start local AI helper: \(m)"
+			case .notConnected: return "Not connected to the local AI helper."
+			case .helperExited: return "Local AI helper exited unexpectedly."
+			case .helperError(let m): return m
+			}
+		}
+	}
+
+	private let socketPath: String
+	private let helperLocator: @Sendable () -> URL?
+	private let queue = DispatchQueue(label: "co.overpolish.ai.helper.client")
+	private var conn: FileHandle?
+
+	/// Fails to init when the app-group socket path is unavailable (missing
+	/// entitlement) - the caller should then fall back.
+	/// - Parameter helperLocator: returns the helper binary in the client's own
+	///   bundle (sandbox only permits exec'ing in-bundle binaries).
+	public init?(helperLocator: @escaping @Sendable () -> URL?) {
+		guard let path = LocalAIHelperSocket.sharedSocketPath() else { return nil }
+		self.socketPath = path
+		self.helperLocator = helperLocator
+	}
+
+	public func complete(
+		modelID: String, system: String, user: String, jsonSchemaJSON: String?,
+		enableThinking: Bool
+	) async throws -> String {
+		let req = HelperRequest(
+			modelID: modelID, system: system, user: user,
+			jsonSchemaJSON: jsonSchemaJSON, enableThinking: enableThinking)
+		return try await withCheckedThrowingContinuation { cont in
+			queue.async {
+				do {
+					cont.resume(returning: try self.exchange(req))
+				} catch {
+					cont.resume(throwing: error)
+				}
+			}
+		}
+	}
+
+	/// Stream a plain-text answer from the helper: send a `stream` request, then
+	/// yield each chunk frame as it arrives until the `done` frame. Runs the whole
+	/// exchange on the serial queue (one request at a time over the single socket).
+	/// A mid-stream transport failure finishes the stream with an error - unlike a
+	/// one-shot call we can't transparently replay a partially-delivered answer.
+	public func completeStreaming(
+		modelID: String, system: String, user: String
+	) async -> AsyncThrowingStream<String, Error> {
+		AsyncThrowingStream { continuation in
+			queue.async {
+				do {
+					try self.ensureConnected()
+					guard let conn = self.conn else { throw HelperError.notConnected }
+					let req = HelperRequest(
+						modelID: modelID, system: system, user: user,
+						jsonSchemaJSON: nil, enableThinking: false, stream: true)
+					try HelperFraming.write(try JSONEncoder().encode(req), to: conn)
+					while true {
+						guard let data = try HelperFraming.read(from: conn) else {
+							throw HelperError.helperExited
+						}
+						let resp = try JSONDecoder().decode(HelperResponse.self, from: data)
+						if let err = resp.error { throw HelperError.helperError(err) }
+						if let status = resp.status {
+							Self.applyStatus(status)
+							continue
+						}
+						// A stale helper that predates streaming ignores the flag and
+						// replies with one `result` frame: deliver it whole and stop, so
+						// we don't block forever waiting for chunk/done frames.
+						if let result = resp.result {
+							continuation.yield(result)
+							break
+						}
+						if resp.done == true { break }
+						if let chunk = resp.chunk { continuation.yield(chunk) }
+					}
+					continuation.finish()
+				} catch {
+					// A dead socket leaves the connection unusable; drop it so the next
+					// call reconnects/respawns.
+					self.teardown()
+					continuation.finish(throwing: error)
+				}
+			}
+		}
+	}
+
+	/// Queue-isolated: ensure connected, send one request, read one response. On a
+	/// transport failure (helper idle-exited / crashed) reconnect once and retry.
+	private func exchange(_ req: HelperRequest) throws -> String {
+		try ensureConnected()
+		do {
+			return try roundtrip(req)
+		} catch let e as HelperError where isTransport(e) {
+			clientLog.notice(
+				"client: transport lost (\(e.localizedDescription, privacy: .public)); reconnecting"
+			)
+			teardown()
+			try ensureConnected()
+			return try roundtrip(req)
+		}
+	}
+
+	private func isTransport(_ e: HelperError) -> Bool {
+		switch e {
+		case .helperExited, .notConnected: return true
+		default: return false
+		}
+	}
+
+	private func roundtrip(_ req: HelperRequest) throws -> String {
+		guard let conn else { throw HelperError.notConnected }
+		let payload = try JSONEncoder().encode(req)
+		do {
+			try HelperFraming.write(payload, to: conn)
+		} catch {
+			throw HelperError.helperExited
+		}
+		// The helper may emit status frames ("Loading model…"/"Thinking…") before
+		// the terminal result frame; surface them, keep reading until the result.
+		while true {
+			let respData: Data?
+			do {
+				respData = try HelperFraming.read(from: conn)
+			} catch {
+				throw HelperError.helperExited
+			}
+			guard let respData else { throw HelperError.helperExited }
+			let resp = try JSONDecoder().decode(HelperResponse.self, from: respData)
+			if let err = resp.error { throw HelperError.helperError(err) }
+			if let status = resp.status {
+				Self.applyStatus(status)
+				continue
+			}
+			if let result = resp.result { return result }
+			// Unexpected frame (e.g. a stray chunk) - ignore and keep reading.
+		}
+	}
+
+	/// Mirror a helper status update into THIS process's draft state so the plugin
+	/// inspector shows what the helper is actually doing (the helper's own
+	/// AIDraftState is in another process and never reaches the UI).
+	private static func applyStatus(_ status: String) {
+		Task { @MainActor in AIDraftState.shared.routingStatus = status }
+	}
+
+	private func ensureConnected() throws {
+		if conn != nil { return }
+
+		if let fd = LocalAIHelperSocket.clientConnect(path: socketPath) {
+			conn = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+			return
+		}
+
+		// Nobody listening - spawn the helper, then poll for the socket. Bind +
+		// listen happens immediately at helper start (before the slow model load),
+		// so this resolves within ~a second; allow generous headroom.
+		try spawnHelper()
+		for _ in 0..<200 {  // ~10s at 50ms
+			if let fd = LocalAIHelperSocket.clientConnect(path: socketPath) {
+				conn = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+				clientLog.notice("client: connected to helper socket")
+				return
+			}
+			usleep(50_000)
+		}
+		throw HelperError.spawnFailed("helper did not come up at \(socketPath)")
+	}
+
+	private func spawnHelper() throws {
+		guard let exe = helperLocator() else {
+			throw HelperError.spawnFailed("helper binary not found in bundle")
+		}
+		guard FileManager.default.fileExists(atPath: exe.path) else {
+			throw HelperError.spawnFailed("missing at \(exe.path)")
+		}
+		let p = Process()
+		p.executableURL = exe
+		// CRITICAL for speed: a detached helper otherwise runs at background QoS
+		// (efficiency cores + low GPU priority), making MLX generation ~10-15x
+		// slower than the old in-process path. Pin it to user-initiated so it gets
+		// performance cores and competes for the GPU with FCP's foreground work.
+		p.qualityOfService = .userInitiated
+		// Hand the helper the resolved socket path so it needs no app-group
+		// entitlement of its own (it binds the path; filesystem access to the
+		// group container is inherited from our sandbox).
+		p.arguments = ["--socket", socketPath]
+		// Point the helper at the SHARED model cache via HF_HUB_CACHE. It's read
+		// from the process environment at startup (ProcessInfo snapshots it), so a
+		// freshly spawned child picks it up - and every helper, whoever spawns it,
+		// then loads from the one app-group cache instead of re-downloading.
+		if let cacheDir = LocalAIHelperSocket.sharedModelCacheDir() {
+			var env = ProcessInfo.processInfo.environment
+			env["HF_HUB_CACHE"] = cacheDir.path
+			p.environment = env
+		}
+		// The protocol is the socket; silence the child's stdout/stderr (MLX is
+		// chatty) so it never pollutes the spawner. The helper logs via os.Logger.
+		p.standardInput = FileHandle.nullDevice
+		p.standardOutput = FileHandle.nullDevice
+		p.standardError = FileHandle.nullDevice
+		do {
+			try p.run()
+		} catch {
+			clientLog.error("client: spawn FAILED: \(error.localizedDescription, privacy: .public)")
+			throw HelperError.spawnFailed(error.localizedDescription)
+		}
+		// Do NOT wait/retain: the helper detaches and outlives us (reparented to
+		// launchd), so it can keep serving other clients after we exit.
+		clientLog.notice(
+			"client: spawned helper \(exe.lastPathComponent, privacy: .public) pid \(p.processIdentifier, privacy: .public)"
+		)
+	}
+
+	private func teardown() {
+		try? conn?.close()
+		conn = nil
+	}
+
+	deinit {
+		teardown()
+	}
+}

--- a/KeyframelessAI/Sources/KeyframelessAI/Resources/Localizable.xcstrings
+++ b/KeyframelessAI/Sources/KeyframelessAI/Resources/Localizable.xcstrings
@@ -1,2401 +1,2399 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "%lld selected · transforms apply here": {
-      "comment": "Steno selection line when one or more transcriptions are selected.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld ausgewählt · Transformationen werden hier angewendet"
+  "sourceLanguage" : "en",
+  "strings" : {
+    "%lld selected · transforms apply here" : {
+      "comment" : "Steno selection line when one or more transcriptions are selected.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld ausgewählt · Transformationen werden hier angewendet"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld seleccionados · las transformaciones se aplican aquí"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld seleccionados · las transformaciones se aplican aquí"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld sélectionné(s) · les transformations s'appliquent ici"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld sélectionné(s) · les transformations s'appliquent ici"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld 件選択中 · 変換はここに適用されます"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 件選択中 · 変換はここに適用されます"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld개 선택됨 · 변환이 여기에 적용됩니다"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld개 선택됨 · 변환이 여기에 적용됩니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已选择 %lld 个 · 变换在此应用"
-          }
-        }
-      }
-    },
-    "%lld%%": {},
-    "AI": {
-      "comment": "Tooltip on the AI button when idle.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "KI"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IA"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IA"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AI"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AI"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AI"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已选择 %lld 个 · 变换在此应用"
           }
         }
       }
     },
-    "API Key": {
-      "comment": "Label for the API key entry field.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "API-Schlüssel"
+    "%lld%%" : {
+
+    },
+    "Action" : {
+      "comment" : "Tab label: the run/action tab.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktion"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clave de API"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acción"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clé d'API"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Action"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "APIキー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクション"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "API 키"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "API 密钥"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作"
           }
         }
       }
     },
-    "Action": {
-      "comment": "Tab label: the run/action tab.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktion"
+    "AI" : {
+      "comment" : "Tooltip on the AI button when idle.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KI"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acción"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IA"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Action"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IA"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アクション"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "작업"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "操作"
-          }
-        }
-      }
-    },
-    "Best quality, needs 24 GB": {
-      "comment": "Blurb for the Gemma 4 26B local model.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beste Qualität, braucht 24 GB"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Máxima calidad, necesita 24 GB"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Qualité optimale, 24 Go requis"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最高品質、24 GB 必要"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "최고 품질, 24 GB 필요"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最佳质量，需要 24 GB"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI"
           }
         }
       }
     },
-    "Config": {
-      "comment": "Tab label: the configuration/key tab.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konfiguration"
+    "API Key" : {
+      "comment" : "Label for the API key entry field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Schlüssel"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuración"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave de API"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuration"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé d'API"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "APIキー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API 키"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "配置"
-          }
-        }
-      }
-    },
-    "Configure AI key": {
-      "comment": "Tooltip on the AI button when no key is configured.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "KI-Schlüssel konfigurieren"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configurar clave de IA"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configurer la clé d'IA"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AIキーを設定"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AI 키 설정"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "配置 AI 密钥"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API 密钥"
           }
         }
       }
     },
-    "Couldn't delete: %@": {
-      "comment": "Error shown when deleting a saved key fails. %@ is the system error.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Löschen fehlgeschlagen: %@"
+    "Config" : {
+      "comment" : "Tab label: the configuration/key tab.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfiguration"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo eliminar: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuración"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Échec de la suppression : %@"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuration"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "削除できませんでした: %@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "삭제할 수 없습니다: %@"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法删除：%@"
-          }
-        }
-      }
-    },
-    "Couldn't figure out which lanes to change.": {
-      "comment": "AI fallback answer when no editable lanes were resolved.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konnte nicht ermitteln, welche Spuren geändert werden sollen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo determinar qué pistas cambiar."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impossible de déterminer quelles pistes modifier."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "変更するレーンを特定できませんでした。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "변경할 레인을 파악하지 못했습니다."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法确定要更改哪些轨道。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置"
           }
         }
       }
     },
-    "Couldn't reach the on-device model service.": {
-      "comment": "Error when the local model runner is unavailable.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der geräteinterne Modelldienst ist nicht erreichbar."
+    "Configure AI key" : {
+      "comment" : "Tooltip on the AI button when no key is configured.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KI-Schlüssel konfigurieren"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo acceder al servicio de modelo en el dispositivo."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurar clave de IA"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impossible de joindre le service de modèle sur l'appareil."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurer la clé d'IA"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "デバイス上のモデルサービスに接続できませんでした。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AIキーを設定"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기기 내 모델 서비스에 연결할 수 없습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 키 설정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法连接设备端模型服务。"
-          }
-        }
-      }
-    },
-    "Couldn't run the on-device model.": {
-      "comment": "Error when the on-device model can't run (engine not ready or load failed).",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Das On-Device-Modell konnte nicht ausgeführt werden."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo ejecutar el modelo en el dispositivo."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impossible d'exécuter le modèle sur l'appareil."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "デバイス上のモデルを実行できませんでした。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기기 내 모델을 실행할 수 없습니다."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法运行设备端模型。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置 AI 密钥"
           }
         }
       }
     },
-    "Delete": {
-      "comment": "Button: delete the saved API key.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Löschen"
+    "Couldn't delete: %@" : {
+      "comment" : "Error shown when deleting a saved key fails. %@ is the system error.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Löschen fehlgeschlagen: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eliminar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo eliminar: %@"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de la suppression : %@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "削除"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除できませんでした: %@"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "삭제"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "삭제할 수 없습니다: %@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "删除"
-          }
-        }
-      }
-    },
-    "Describe what to do to the selected transcriptions…": {
-      "comment": "Default prompt placeholder for the Steno AI field.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beschreibe, was mit den ausgewählten Transkriptionen geschehen soll…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Describe qué hacer con las transcripciones seleccionadas…"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Décrivez ce qu'il faut faire avec les transcriptions sélectionnées…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択した文字起こしに対する処理を入力…"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "선택한 전사에 대해 수행할 작업을 설명하세요…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "描述要对所选转录执行的操作…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法删除：%@"
           }
         }
       }
     },
-    "Dismiss answer": {
-      "comment": "Tooltip on the button that clears the last AI answer.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Antwort schließen"
+    "Couldn't figure out which lanes to change." : {
+      "comment" : "AI fallback answer when no editable lanes were resolved.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konnte nicht ermitteln, welche Spuren geändert werden sollen."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descartar respuesta"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo determinar qué pistas cambiar."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ignorer la réponse"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de déterminer quelles pistes modifier."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "回答を閉じる"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変更するレーンを特定できませんでした。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "답변 닫기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "변경할 레인을 파악하지 못했습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "关闭回答"
-          }
-        }
-      }
-    },
-    "Done": {
-      "comment": "Run button label after a transform has been applied.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fertig"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Listo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminé"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完了"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "완료"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完成"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法确定要更改哪些轨道。"
           }
         }
       }
     },
-    "Done - click to review": {
-      "comment": "Tooltip on the AI button after a transform completes.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fertig - zum Überprüfen klicken"
+    "Couldn't reach the on-device model service." : {
+      "comment" : "Error when the local model runner is unavailable.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der geräteinterne Modelldienst ist nicht erreichbar."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Listo - haz clic para revisar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo acceder al servicio de modelo en el dispositivo."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminé - cliquez pour vérifier"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de joindre le service de modèle sur l'appareil."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完了 - クリックして確認"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバイス上のモデルサービスに接続できませんでした。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "완료 - 클릭하여 검토"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기기 내 모델 서비스에 연결할 수 없습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完成 - 点击查看"
-          }
-        }
-      }
-    },
-    "Download": {
-      "comment": "Button to download a local model.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Laden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Télécharger"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダウンロード"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "다운로드"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下载"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法连接设备端模型服务。"
           }
         }
       }
     },
-    "Examples": {
-      "comment": "Section header above the example prompt chips.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beispiele"
+    "Couldn't run the on-device model." : {
+      "comment" : "Error when the on-device model can't run (engine not ready or load failed).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das On-Device-Modell konnte nicht ausgeführt werden."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ejemplos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo ejecutar el modelo en el dispositivo."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exemples"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d'exécuter le modèle sur l'appareil."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "例"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバイス上のモデルを実行できませんでした。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "예시"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기기 내 모델을 실행할 수 없습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "示例"
-          }
-        }
-      }
-    },
-    "Expand all contractions (don't → do not)": {
-      "comment": "Example prompt value: expand contractions.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle Kurzformen auflösen (don't → do not)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expandir todas las contracciones (don't → do not)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Développer toutes les contractions (don't → do not)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべての短縮形を展開する (don't → do not)"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모든 축약형 풀어쓰기 (don't → do not)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "展开所有缩写 (don't → do not)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法运行设备端模型。"
           }
         }
       }
     },
-    "Expand contractions": {
-      "comment": "Example prompt label: expand contractions.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kurzformen auflösen"
+    "Delete" : {
+      "comment" : "Button: delete the saved API key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Löschen"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expandir contracciones"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Développer les contractions"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "短縮形を展開"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "축약형 풀어쓰기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "삭제"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "展开缩写"
-          }
-        }
-      }
-    },
-    "Fix capitalization": {
-      "comment": "Example prompt label: fix capitalization.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Großschreibung korrigieren"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Corregir mayúsculas"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Corriger la casse"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "大文字小文字を修正"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "대소문자 수정"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "修正大小写"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除"
           }
         }
       }
     },
-    "Fix capitalization and punctuation": {
-      "comment": "Example prompt value: fix capitalization and punctuation.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Großschreibung und Zeichensetzung korrigieren"
+    "Describe what to do to the selected transcriptions…" : {
+      "comment" : "Default prompt placeholder for the Steno AI field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beschreibe, was mit den ausgewählten Transkriptionen geschehen soll…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Corregir mayúsculas y puntuación"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Describe qué hacer con las transcripciones seleccionadas…"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Corriger la casse et la ponctuation"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Décrivez ce qu'il faut faire avec les transcriptions sélectionnées…"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "大文字小文字と句読点を修正する"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択した文字起こしに対する処理を入力…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "대소문자와 문장 부호 수정"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택한 전사에 대해 수행할 작업을 설명하세요…"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "修正大小写和标点符号"
-          }
-        }
-      }
-    },
-    "Get a key": {
-      "comment": "Link to the provider's API key console.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schlüssel erhalten"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obtener una clave"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obtenir une clé"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーを取得"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키 받기"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "获取密钥"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "描述要对所选转录执行的操作…"
           }
         }
       }
     },
-    "Key works": {
-      "comment": "Status shown when an API key validates successfully.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schlüssel funktioniert"
+    "Dismiss answer" : {
+      "comment" : "Tooltip on the button that clears the last AI answer.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Antwort schließen"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La clave funciona"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descartar respuesta"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La clé fonctionne"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignorer la réponse"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーは有効です"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回答を閉じる"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키가 작동합니다"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "답변 닫기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "密钥有效"
-          }
-        }
-      }
-    },
-    "Last answer": {
-      "comment": "Header above the last AI answer card.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Letzte Antwort"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Última respuesta"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dernière réponse"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "前回の回答"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "마지막 답변"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "上一个回答"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭回答"
           }
         }
       }
     },
-    "Light and fast, any modern Mac": {
-      "comment": "Blurb for the Gemma local model.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leicht und schnell, jeder Mac"
+    "Done" : {
+      "comment" : "Run button label after a transform has been applied.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ligero y rápido, cualquier Mac"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listo"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Léger et rapide, tout Mac"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminé"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "軽量・高速、どの Mac でも"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가볍고 빠름, 모든 Mac"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "轻量快速，任何 Mac"
-          }
-        }
-      }
-    },
-    "Loading model…": {
-      "comment": "AI button status while the local model loads into memory.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modell wird geladen…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cargando modelo…"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chargement du modèle…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "モデルを読み込み中…"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모델 로딩 중…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在加载模型…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
           }
         }
       }
     },
-    "Local": {
-      "comment": "Provider name for on-device local models.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lokal"
+    "Done - click to review" : {
+      "comment" : "Tooltip on the AI button after a transform completes.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig - zum Überprüfen klicken"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listo - haz clic para revisar"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminé - cliquez pour vérifier"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカル"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了 - クリックして確認"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "로컬"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료 - 클릭하여 검토"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本地"
-          }
-        }
-      }
-    },
-    "Make formal": {
-      "comment": "Example prompt label: make formal.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formeller machen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hacer formal"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rendre formel"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フォーマルにする"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "격식체로 변경"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "改为正式语气"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成 - 点击查看"
           }
         }
       }
     },
-    "No key": {
-      "comment": "Badge next to a provider in the picker that has no stored key.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kein Schlüssel"
+    "Download" : {
+      "comment" : "Button to download a local model.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laden"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin clave"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargar"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucune clé"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Télécharger"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーなし"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키 없음"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无密钥"
-          }
-        }
-      }
-    },
-    "No key for %@": {
-      "comment": "Footer warning when the active provider has no key. %@ is the provider name.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kein Schlüssel für %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin clave para %@"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucune clé pour %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ のキーがありません"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@에 대한 키가 없습니다"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "没有 %@ 的密钥"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载"
           }
         }
       }
     },
-    "No model": {
-      "comment": "Badge next to the local provider when no model is downloaded.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kein Modell"
+    "Examples" : {
+      "comment" : "Section header above the example prompt chips.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beispiele"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin modelo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ejemplos"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucun modèle"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exemples"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "モデルなし"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모델 없음"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예시"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无模型"
-          }
-        }
-      }
-    },
-    "No model selected": {
-      "comment": "Warning when the local provider is active but no model is selected.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kein Modell ausgewählt"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ningún modelo seleccionado"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucun modèle sélectionné"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "モデルが選択されていません"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "선택된 모델 없음"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未选择模型"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "示例"
           }
         }
       }
     },
-    "No selection · transforms unavailable, questions still work": {
-      "comment": "Steno selection line when nothing is selected.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine Auswahl · Transformationen nicht verfügbar, Fragen funktionieren weiterhin"
+    "Expand all contractions (don't → do not)" : {
+      "comment" : "Example prompt value: expand contractions.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Kurzformen auflösen (don't → do not)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin selección · transformaciones no disponibles, las preguntas siguen funcionando"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expandir todas las contracciones (don't → do not)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucune sélection · transformations indisponibles, les questions fonctionnent toujours"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Développer toutes les contractions (don't → do not)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択なし · 変換は利用できません。質問は引き続き使えます"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべての短縮形を展開する (don't → do not)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "선택 없음 · 변환을 사용할 수 없지만 질문은 가능합니다"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 축약형 풀어쓰기 (don't → do not)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未选择 · 变换不可用，但仍可提问"
-          }
-        }
-      }
-    },
-    "On-device models": {
-      "comment": "Header for the local model manager.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modelle auf dem Gerät"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modelos en el dispositivo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modèles sur l'appareil"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "デバイス上のモデル"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기기 내 모델"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "设备端模型"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展开所有缩写 (don't → do not)"
           }
         }
       }
     },
-    "Paste %@…": {
-      "comment": "API key field placeholder. %@ is a key-prefix hint like sk-ant.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ einfügen…"
+    "Expand contractions" : {
+      "comment" : "Example prompt label: expand contractions.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kurzformen auflösen"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pega %@…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expandir contracciones"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coller %@…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Développer les contractions"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ を貼り付け…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "短縮形を展開"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 붙여넣기…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "축약형 풀어쓰기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "粘贴 %@…"
-          }
-        }
-      }
-    },
-    "Planning timing…": {
-      "comment": "AI routing status: planning the timing pass.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Timing wird geplant…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Planificando el tiempo…"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Planification du timing…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タイミングを計画中…"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "타이밍 계획 중…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在规划计时…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展开缩写"
           }
         }
       }
     },
-    "Reading prompt…": {
-      "comment": "AI routing status: reading/classifying the prompt.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eingabe wird gelesen…"
+    "Fast and capable" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schnell und leistungsfähig"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leyendo la indicación…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rápido y capaz"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lecture de la requête…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapide et performant"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プロンプトを読み取り中…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高速で高性能"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "프롬프트 읽는 중…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "빠르고 유능함"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在读取提示…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速且强大"
           }
         }
       }
     },
-    "Recent": {
-      "comment": "Section header above recent prompt chips.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zuletzt verwendet"
+    "Fix capitalization" : {
+      "comment" : "Example prompt label: fix capitalization.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Großschreibung korrigieren"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recientes"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corregir mayúsculas"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Récents"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corriger la casse"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最近"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大文字小文字を修正"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "최근"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대소문자 수정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最近"
-          }
-        }
-      }
-    },
-    "Recommended": {
-      "comment": "Badge on the hardware-recommended local model.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Empfohlen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recomendado"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recommandé"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "おすすめ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "추천"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "推荐"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "修正大小写"
           }
         }
       }
     },
-    "Recommended is based on your Mac": {
-      "comment": "Hint that the recommendation is hardware-based.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Empfehlung basiert auf deinem Mac"
+    "Fix capitalization and punctuation" : {
+      "comment" : "Example prompt value: fix capitalization and punctuation.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Großschreibung und Zeichensetzung korrigieren"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La recomendación se basa en tu Mac"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corregir mayúsculas y puntuación"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La recommandation dépend de votre Mac"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corriger la casse et la ponctuation"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "おすすめはお使いの Mac に基づきます"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大文字小文字と句読点を修正する"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "추천은 사용 중인 Mac을 기준으로 합니다"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대소문자와 문장 부호 수정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "推荐基于你的 Mac"
-          }
-        }
-      }
-    },
-    "Remove filler words like uh, um, like, you know": {
-      "comment": "Example prompt value: strip filler words.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Füllwörter wie ähm, äh, also, weißt du entfernen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eliminar muletillas como eh, em, o sea, ya sabes"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer les mots de remplissage comme euh, hum, genre, tu vois"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "「えー」「あの」「えっと」などのつなぎ言葉を削除する"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "음, 어, 그, 있잖아 같은 군더더기 표현 제거"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "去除「呃、嗯、就是、你知道」之类的填充词"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "修正大小写和标点符号"
           }
         }
       }
     },
-    "Resolving %@…": {
-      "comment": "AI routing status while resolving a lane. %@ is the lane name (plus an optional progress suffix like \" (1/2)\").",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ wird aufgelöst…"
+    "Get a key" : {
+      "comment" : "Link to the provider's API key console.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schlüssel erhalten"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resolviendo %@…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtener una clave"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Résolution de %@…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtenir une clé"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ を解決中…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キーを取得"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 확인 중…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키 받기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在解析 %@…"
-          }
-        }
-      }
-    },
-    "Rewrite in a formal tone": {
-      "comment": "Example prompt value: make formal.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "In einem formellen Ton umschreiben"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reescribir en un tono formal"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réécrire sur un ton formel"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フォーマルな口調に書き換える"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "격식 있는 어조로 다시 작성"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "用正式语气重写"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取密钥"
           }
         }
       }
     },
-    "Run": {
-      "comment": "Run button: submit the prompt.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ausführen"
+    "Key works" : {
+      "comment" : "Status shown when an API key validates successfully.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schlüssel funktioniert"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ejecutar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La clave funciona"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exécuter"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La clé fonctionne"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "実行"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キーは有効です"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "실행"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키가 작동합니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "运行"
-          }
-        }
-      }
-    },
-    "Runs entirely on your Mac.": {
-      "comment": "Short footnote in the local model manager.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Läuft vollständig auf deinem Mac."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se ejecuta por completo en tu Mac."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fonctionne entièrement sur votre Mac."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべてお使いの Mac 上で動作します。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전적으로 Mac에서 실행됩니다."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完全在你的 Mac 上运行。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密钥有效"
           }
         }
       }
     },
-    "Save": {
-      "comment": "Button: save the API key.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Speichern"
+    "Last answer" : {
+      "comment" : "Header above the last AI answer card.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte Antwort"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guardar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Última respuesta"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enregistrer"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dernière réponse"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保存"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前回の回答"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "저장"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마지막 답변"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保存"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一个回答"
           }
         }
       }
     },
-    "Saved - paste to replace": {
-      "comment": "API key field placeholder when a key is already stored.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gespeichert - zum Ersetzen einfügen"
+    "Light and fast, any modern Mac" : {
+      "comment" : "Blurb for the Gemma local model.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leicht und schnell, jeder Mac"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guardado - pega para reemplazar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ligero y rápido, cualquier Mac"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enregistré - collez pour remplacer"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Léger et rapide, tout Mac"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保存済み - 貼り付けて置き換え"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "軽量・高速、どの Mac でも"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "저장됨 - 붙여넣어 교체"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가볍고 빠름, 모든 Mac"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已保存 - 粘贴以替换"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "轻量快速，任何 Mac"
           }
         }
       }
     },
-    "Strip filler words": {
-      "comment": "Example prompt label: strip filler words.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Füllwörter entfernen"
+    "Loading model…" : {
+      "comment" : "AI button status while the local model loads into memory.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell wird geladen…"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quitar muletillas"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando modelo…"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer les mots de remplissage"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chargement du modèle…"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "つなぎ言葉を削除"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデルを読み込み中…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "군더더기 표현 제거"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모델 로딩 중…"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "去除填充词"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在加载模型…"
           }
         }
       }
     },
-    "Strong reasoning, needs 16 GB": {
-      "comment": "Blurb for the Qwen local model.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Starkes Reasoning, braucht 16 GB"
+    "Local" : {
+      "comment" : "Provider name for on-device local models.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lokal"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Razonamiento potente, necesita 16 GB"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Raisonnement solide, 16 Go requis"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "高い推論、16 GB 必要"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローカル"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "강력한 추론, 16 GB 필요"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로컬"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "强大推理，需要 16 GB"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地"
           }
         }
       }
     },
-    "Strongest reasoning, needs 16 GB": {
-      "comment": "Blurb for the Qwen local model.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stärkstes Reasoning, braucht 16 GB"
+    "Make formal" : {
+      "comment" : "Example prompt label: make formal.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Formeller machen"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Máximo razonamiento, necesita 16 GB"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hacer formal"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Raisonnement maximal, 16 Go requis"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendre formel"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最高の推論、16 GB 必要"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォーマルにする"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "최고 추론, 16 GB 필요"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "격식체로 변경"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最强推理，需要 16 GB"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "改为正式语气"
           }
         }
       }
     },
-    "Testing connection…": {
-      "comment": "Status shown while validating an API key.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verbindung wird getestet…"
+    "No key" : {
+      "comment" : "Badge next to a provider in the picker that has no stored key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Schlüssel"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Probando conexión…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin clave"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Test de la connexion…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune clé"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続をテスト中…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キーなし"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "연결 테스트 중…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키 없음"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在测试连接…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无密钥"
           }
         }
       }
     },
-    "Thinking…": {
-      "comment": "Fallback status next to the Run spinner.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Denkt nach…"
+    "No key for %@" : {
+      "comment" : "Footer warning when the active provider has no key. %@ is the provider name.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Schlüssel für %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pensando…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin clave para %@"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réflexion…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune clé pour %@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "思考中…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ のキーがありません"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "생각 중…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@에 대한 키가 없습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "思考中…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有 %@ 的密钥"
           }
         }
       }
     },
-    "Translate into ": {
-      "comment": "Example prompt value: translate into (trailing space, user completes the language).",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Übersetzen nach "
+    "No model" : {
+      "comment" : "Badge next to the local provider when no model is downloaded.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Modell"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Traducir a "
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin modelo"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Traduire en "
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun modèle"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "次の言語に翻訳: "
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデルなし"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "다음으로 번역: "
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모델 없음"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "翻译为 "
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无模型"
           }
         }
       }
     },
-    "Translate to…": {
-      "comment": "Example prompt label: translate to.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Übersetzen nach…"
+    "No model selected" : {
+      "comment" : "Warning when the local provider is active but no model is selected.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Modell ausgewählt"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Traducir a…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ningún modelo seleccionado"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Traduire en…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun modèle sélectionné"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "翻訳先…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデルが選択されていません"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "번역 대상…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택된 모델 없음"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "翻译为…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择模型"
           }
         }
       }
     },
-    "Uninstall": {
-      "comment": "Context-menu action to remove a downloaded local model.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entfernen"
+    "No selection · transforms unavailable, questions still work" : {
+      "comment" : "Steno selection line when nothing is selected.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Auswahl · Transformationen nicht verfügbar, Fragen funktionieren weiterhin"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desinstalar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin selección · transformaciones no disponibles, las preguntas siguen funcionando"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Désinstaller"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune sélection · transformations indisponibles, les questions fonctionnent toujours"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アンインストール"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択なし · 変換は利用できません。質問は引き続き使えます"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제거"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택 없음 · 변환을 사용할 수 없지만 질문은 가능합니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "卸载"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择 · 变换不可用，但仍可提问"
           }
         }
       }
     },
-    "Working…": {
-      "comment": "Tooltip on the AI button while a request is in flight.",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arbeitet…"
+    "On-device models" : {
+      "comment" : "Header for the local model manager.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modelle auf dem Gerät"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trabajando…"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modelos en el dispositivo"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "En cours…"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modèles sur l'appareil"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "処理中…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバイス上のモデル"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "작업 중…"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기기 내 모델"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "处理中…"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备端模型"
+          }
+        }
+      }
+    },
+    "Paste %@…" : {
+      "comment" : "API key field placeholder. %@ is a key-prefix hint like sk-ant.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ einfügen…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pega %@…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coller %@…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ を貼り付け…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 붙여넣기…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴 %@…"
+          }
+        }
+      }
+    },
+    "Planning timing…" : {
+      "comment" : "AI routing status: planning the timing pass.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timing wird geplant…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Planificando el tiempo…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Planification du timing…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイミングを計画中…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "타이밍 계획 중…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在规划计时…"
+          }
+        }
+      }
+    },
+    "Reading prompt…" : {
+      "comment" : "AI routing status: reading/classifying the prompt.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eingabe wird gelesen…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leyendo la indicación…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture de la requête…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロンプトを読み取り中…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "프롬프트 읽는 중…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在读取提示…"
+          }
+        }
+      }
+    },
+    "Recent" : {
+      "comment" : "Section header above recent prompt chips.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zuletzt verwendet"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recientes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Récents"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近"
+          }
+        }
+      }
+    },
+    "Recommended" : {
+      "comment" : "Badge on the hardware-recommended local model.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empfohlen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recomendado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recommandé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "おすすめ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推荐"
+          }
+        }
+      }
+    },
+    "Recommended is based on your Mac" : {
+      "comment" : "Hint that the recommendation is hardware-based.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empfehlung basiert auf deinem Mac"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La recomendación se basa en tu Mac"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La recommandation dépend de votre Mac"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "おすすめはお使いの Mac に基づきます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천은 사용 중인 Mac을 기준으로 합니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推荐基于你的 Mac"
+          }
+        }
+      }
+    },
+    "Remove filler words like uh, um, like, you know" : {
+      "comment" : "Example prompt value: strip filler words.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Füllwörter wie ähm, äh, also, weißt du entfernen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar muletillas como eh, em, o sea, ya sabes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer les mots de remplissage comme euh, hum, genre, tu vois"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「えー」「あの」「えっと」などのつなぎ言葉を削除する"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "음, 어, 그, 있잖아 같은 군더더기 표현 제거"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去除「呃、嗯、就是、你知道」之类的填充词"
+          }
+        }
+      }
+    },
+    "Resolving %@…" : {
+      "comment" : "AI routing status while resolving a lane. %@ is the lane name (plus an optional progress suffix like \" (1/2)\").",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ wird aufgelöst…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resolviendo %@…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Résolution de %@…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ を解決中…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 확인 중…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在解析 %@…"
+          }
+        }
+      }
+    },
+    "Rewrite in a formal tone" : {
+      "comment" : "Example prompt value: make formal.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In einem formellen Ton umschreiben"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reescribir en un tono formal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réécrire sur un ton formel"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォーマルな口調に書き換える"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "격식 있는 어조로 다시 작성"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用正式语气重写"
+          }
+        }
+      }
+    },
+    "Run" : {
+      "comment" : "Run button: submit the prompt.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ausführen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ejecutar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exécuter"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "실행"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运行"
+          }
+        }
+      }
+    },
+    "Runs entirely on your Mac." : {
+      "comment" : "Short footnote in the local model manager.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Läuft vollständig auf deinem Mac."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se ejecuta por completo en tu Mac."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fonctionne entièrement sur votre Mac."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてお使いの Mac 上で動作します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전적으로 Mac에서 실행됩니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完全在你的 Mac 上运行。"
+          }
+        }
+      }
+    },
+    "Save" : {
+      "comment" : "Button: save the API key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speichern"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        }
+      }
+    },
+    "Saved - paste to replace" : {
+      "comment" : "API key field placeholder when a key is already stored.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gespeichert - zum Ersetzen einfügen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardado - pega para reemplazar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistré - collez pour remplacer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存済み - 貼り付けて置き換え"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장됨 - 붙여넣어 교체"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保存 - 粘贴以替换"
+          }
+        }
+      }
+    },
+    "Smartest, heaviest" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klügste, schwerste"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El más inteligente y exigente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le plus intelligent, le plus lourd"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最も賢く、最も重い"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가장 똑똑하고 무거움"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最智能，最重"
+          }
+        }
+      }
+    },
+    "Strip filler words" : {
+      "comment" : "Example prompt label: strip filler words.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Füllwörter entfernen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitar muletillas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer les mots de remplissage"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "つなぎ言葉を削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "군더더기 표현 제거"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去除填充词"
+          }
+        }
+      }
+    },
+    "Strongest reasoning, needs 16 GB" : {
+      "comment" : "Blurb for the Qwen local model.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stärkstes Reasoning, braucht 16 GB"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máximo razonamiento, necesita 16 GB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raisonnement maximal, 16 Go requis"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最高の推論、16 GB 必要"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최고 추론, 16 GB 필요"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最强推理，需要 16 GB"
+          }
+        }
+      }
+    },
+    "Testing connection…" : {
+      "comment" : "Status shown while validating an API key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbindung wird getestet…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Probando conexión…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test de la connexion…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接続をテスト中…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연결 테스트 중…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在测试连接…"
+          }
+        }
+      }
+    },
+    "Thinking…" : {
+      "comment" : "Fallback status next to the Run spinner.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Denkt nach…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pensando…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réflexion…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "思考中…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "생각 중…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "思考中…"
+          }
+        }
+      }
+    },
+    "Translate into " : {
+      "comment" : "Example prompt value: translate into (trailing space, user completes the language).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Übersetzen nach "
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traducir a "
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traduire en "
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次の言語に翻訳: "
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음으로 번역: "
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻译为 "
+          }
+        }
+      }
+    },
+    "Translate to…" : {
+      "comment" : "Example prompt label: translate to.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Übersetzen nach…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traducir a…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traduire en…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳先…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "번역 대상…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻译为…"
+          }
+        }
+      }
+    },
+    "Uninstall" : {
+      "comment" : "Context-menu action to remove a downloaded local model.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desinstalar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désinstaller"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アンインストール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제거"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "卸载"
+          }
+        }
+      }
+    },
+    "Working…" : {
+      "comment" : "Tooltip on the AI button while a request is in flight.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arbeitet…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trabajando…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En cours…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "処理中…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 중…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "处理中…"
           }
         }
       }
     }
   },
-  "version": "1.0"
+  "version" : "1.0"
 }

--- a/KeyframelessAI/Sources/KeyframelessAI/Resources/Localizable.xcstrings
+++ b/KeyframelessAI/Sources/KeyframelessAI/Resources/Localizable.xcstrings
@@ -1,498 +1,2401 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "%lld selected · transforms apply here" : {
-      "comment" : "Steno selection line when one or more transcriptions are selected.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "%lld ausgewählt · Transformationen werden hier angewendet" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "%lld seleccionados · las transformaciones se aplican aquí" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "%lld sélectionné(s) · les transformations s'appliquent ici" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%lld 件選択中 · 変換はここに適用されます" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "%lld개 선택됨 · 변환이 여기에 적용됩니다" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "已选择 %lld 个 · 变换在此应用" } }
+  "sourceLanguage": "en",
+  "strings": {
+    "%lld selected · transforms apply here": {
+      "comment": "Steno selection line when one or more transcriptions are selected.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld ausgewählt · Transformationen werden hier angewendet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld seleccionados · las transformaciones se aplican aquí"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld sélectionné(s) · les transformations s'appliquent ici"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 件選択中 · 変換はここに適用されます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld개 선택됨 · 변환이 여기에 적용됩니다"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已选择 %lld 个 · 变换在此应用"
+          }
+        }
       }
     },
-    "AI" : {
-      "comment" : "Tooltip on the AI button when idle.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "KI" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "IA" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "IA" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "AI" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "AI" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "AI" } }
+    "%lld%%": {},
+    "AI": {
+      "comment": "Tooltip on the AI button when idle.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IA"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IA"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI"
+          }
+        }
       }
     },
-    "Action" : {
-      "comment" : "Tab label: the run/action tab.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Aktion" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Acción" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Action" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アクション" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "작업" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "操作" } }
+    "API Key": {
+      "comment": "Label for the API key entry field.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clave de API"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clé d'API"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 키"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥"
+          }
+        }
       }
     },
-    "API Key" : {
-      "comment" : "Label for the API key entry field.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "API-Schlüssel" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Clave de API" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Clé d'API" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "APIキー" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "API 키" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "API 密钥" } }
+    "Action": {
+      "comment": "Tab label: the run/action tab.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktion"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Action"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクション"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作"
+          }
+        }
       }
     },
-    "Config" : {
-      "comment" : "Tab label: the configuration/key tab.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Konfiguration" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Configuración" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Configuration" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "設定" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "설정" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "配置" } }
+    "Best quality, needs 24 GB": {
+      "comment": "Blurb for the Gemma 4 26B local model.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beste Qualität, braucht 24 GB"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máxima calidad, necesita 24 GB"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualité optimale, 24 Go requis"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最高品質、24 GB 必要"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최고 품질, 24 GB 필요"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最佳质量，需要 24 GB"
+          }
+        }
       }
     },
-    "Configure AI key" : {
-      "comment" : "Tooltip on the AI button when no key is configured.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "KI-Schlüssel konfigurieren" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Configurar clave de IA" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Configurer la clé d'IA" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "AIキーを設定" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "AI 키 설정" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "配置 AI 密钥" } }
+    "Config": {
+      "comment": "Tab label: the configuration/key tab.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguration"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置"
+          }
+        }
       }
     },
-    "Couldn't figure out which lanes to change." : {
-      "comment" : "AI fallback answer when no editable lanes were resolved.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Konnte nicht ermitteln, welche Spuren geändert werden sollen." } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "No se pudo determinar qué pistas cambiar." } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible de déterminer quelles pistes modifier." } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "変更するレーンを特定できませんでした。" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "변경할 레인을 파악하지 못했습니다." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "无法确定要更改哪些轨道。" } }
+    "Configure AI key": {
+      "comment": "Tooltip on the AI button when no key is configured.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Schlüssel konfigurieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar clave de IA"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurer la clé d'IA"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AIキーを設定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 키 설정"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置 AI 密钥"
+          }
+        }
       }
     },
-    "Couldn't delete: %@" : {
-      "comment" : "Error shown when deleting a saved key fails. %@ is the system error.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Löschen fehlgeschlagen: %@" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "No se pudo eliminar: %@" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Échec de la suppression : %@" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "削除できませんでした: %@" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "삭제할 수 없습니다: %@" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "无法删除：%@" } }
+    "Couldn't delete: %@": {
+      "comment": "Error shown when deleting a saved key fails. %@ is the system error.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen fehlgeschlagen: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo eliminar: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la suppression : %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除できませんでした: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제할 수 없습니다: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法删除：%@"
+          }
+        }
       }
     },
-    "Describe what to do to the selected transcriptions…" : {
-      "comment" : "Default prompt placeholder for the Steno AI field.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Beschreibe, was mit den ausgewählten Transkriptionen geschehen soll…" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Describe qué hacer con las transcripciones seleccionadas…" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Décrivez ce qu'il faut faire avec les transcriptions sélectionnées…" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "選択した文字起こしに対する処理を入力…" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "선택한 전사에 대해 수행할 작업을 설명하세요…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "描述要对所选转录执行的操作…" } }
+    "Couldn't figure out which lanes to change.": {
+      "comment": "AI fallback answer when no editable lanes were resolved.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konnte nicht ermitteln, welche Spuren geändert werden sollen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo determinar qué pistas cambiar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de déterminer quelles pistes modifier."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更するレーンを特定できませんでした。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "변경할 레인을 파악하지 못했습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法确定要更改哪些轨道。"
+          }
+        }
       }
     },
-    "Delete" : {
-      "comment" : "Button: delete the saved API key.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Löschen" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Eliminar" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Supprimer" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "削除" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "삭제" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "删除" } }
+    "Couldn't reach the on-device model service.": {
+      "comment": "Error when the local model runner is unavailable.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der geräteinterne Modelldienst ist nicht erreichbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo acceder al servicio de modelo en el dispositivo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de joindre le service de modèle sur l'appareil."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバイス上のモデルサービスに接続できませんでした。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기기 내 모델 서비스에 연결할 수 없습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法连接设备端模型服务。"
+          }
+        }
       }
     },
-    "Dismiss answer" : {
-      "comment" : "Tooltip on the button that clears the last AI answer.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Antwort schließen" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Descartar respuesta" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ignorer la réponse" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "回答を閉じる" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "답변 닫기" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "关闭回答" } }
+    "Couldn't run the on-device model.": {
+      "comment": "Error when the on-device model can't run (engine not ready or load failed).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das On-Device-Modell konnte nicht ausgeführt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo ejecutar el modelo en el dispositivo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'exécuter le modèle sur l'appareil."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバイス上のモデルを実行できませんでした。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기기 내 모델을 실행할 수 없습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法运行设备端模型。"
+          }
+        }
       }
     },
-    "Done" : {
-      "comment" : "Run button label after a transform has been applied.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Fertig" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Listo" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Terminé" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "完了" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "완료" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "完成" } }
+    "Delete": {
+      "comment": "Button: delete the saved API key.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除"
+          }
+        }
       }
     },
-    "Done - click to review" : {
-      "comment" : "Tooltip on the AI button after a transform completes.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Fertig - zum Überprüfen klicken" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Listo - haz clic para revisar" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Terminé - cliquez pour vérifier" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "完了 - クリックして確認" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "완료 - 클릭하여 검토" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "完成 - 点击查看" } }
+    "Describe what to do to the selected transcriptions…": {
+      "comment": "Default prompt placeholder for the Steno AI field.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beschreibe, was mit den ausgewählten Transkriptionen geschehen soll…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Describe qué hacer con las transcripciones seleccionadas…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Décrivez ce qu'il faut faire avec les transcriptions sélectionnées…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択した文字起こしに対する処理を入力…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 전사에 대해 수행할 작업을 설명하세요…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "描述要对所选转录执行的操作…"
+          }
+        }
       }
     },
-    "Examples" : {
-      "comment" : "Section header above the example prompt chips.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Beispiele" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Ejemplos" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Exemples" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "例" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "예시" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "示例" } }
+    "Dismiss answer": {
+      "comment": "Tooltip on the button that clears the last AI answer.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antwort schließen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descartar respuesta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer la réponse"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回答を閉じる"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "답변 닫기"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭回答"
+          }
+        }
       }
     },
-    "Expand all contractions (don't → do not)" : {
-      "comment" : "Example prompt value: expand contractions.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Alle Kurzformen auflösen (don't → do not)" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Expandir todas las contracciones (don't → do not)" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Développer toutes les contractions (don't → do not)" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "すべての短縮形を展開する (don't → do not)" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "모든 축약형 풀어쓰기 (don't → do not)" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "展开所有缩写 (don't → do not)" } }
+    "Done": {
+      "comment": "Run button label after a transform has been applied.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완료"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
+          }
+        }
       }
     },
-    "Expand contractions" : {
-      "comment" : "Example prompt label: expand contractions.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Kurzformen auflösen" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Expandir contracciones" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Développer les contractions" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "短縮形を展開" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "축약형 풀어쓰기" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "展开缩写" } }
+    "Done - click to review": {
+      "comment": "Tooltip on the AI button after a transform completes.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig - zum Überprüfen klicken"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo - haz clic para revisar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminé - cliquez pour vérifier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了 - クリックして確認"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완료 - 클릭하여 검토"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成 - 点击查看"
+          }
+        }
       }
     },
-    "Fix capitalization" : {
-      "comment" : "Example prompt label: fix capitalization.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Großschreibung korrigieren" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Corregir mayúsculas" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Corriger la casse" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "大文字小文字を修正" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "대소문자 수정" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "修正大小写" } }
+    "Download": {
+      "comment": "Button to download a local model.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다운로드"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载"
+          }
+        }
       }
     },
-    "Fix capitalization and punctuation" : {
-      "comment" : "Example prompt value: fix capitalization and punctuation.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Großschreibung und Zeichensetzung korrigieren" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Corregir mayúsculas y puntuación" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Corriger la casse et la ponctuation" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "大文字小文字と句読点を修正する" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "대소문자와 문장 부호 수정" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "修正大小写和标点符号" } }
+    "Examples": {
+      "comment": "Section header above the example prompt chips.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beispiele"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejemplos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exemples"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예시"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "示例"
+          }
+        }
       }
     },
-    "Get a key" : {
-      "comment" : "Link to the provider's API key console.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Schlüssel erhalten" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Obtener una clave" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Obtenir une clé" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "キーを取得" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "키 받기" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "获取密钥" } }
+    "Expand all contractions (don't → do not)": {
+      "comment": "Example prompt value: expand contractions.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Kurzformen auflösen (don't → do not)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expandir todas las contracciones (don't → do not)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Développer toutes les contractions (don't → do not)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての短縮形を展開する (don't → do not)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 축약형 풀어쓰기 (don't → do not)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展开所有缩写 (don't → do not)"
+          }
+        }
       }
     },
-    "Key works" : {
-      "comment" : "Status shown when an API key validates successfully.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Schlüssel funktioniert" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "La clave funciona" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "La clé fonctionne" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "キーは有効です" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "키가 작동합니다" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "密钥有效" } }
+    "Expand contractions": {
+      "comment": "Example prompt label: expand contractions.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kurzformen auflösen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expandir contracciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Développer les contractions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "短縮形を展開"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "축약형 풀어쓰기"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展开缩写"
+          }
+        }
       }
     },
-    "Last answer" : {
-      "comment" : "Header above the last AI answer card.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Letzte Antwort" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Última respuesta" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Dernière réponse" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "前回の回答" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "마지막 답변" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "上一个回答" } }
+    "Fix capitalization": {
+      "comment": "Example prompt label: fix capitalization.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Großschreibung korrigieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corregir mayúsculas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corriger la casse"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大文字小文字を修正"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대소문자 수정"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "修正大小写"
+          }
+        }
       }
     },
-    "Make formal" : {
-      "comment" : "Example prompt label: make formal.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Formeller machen" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Hacer formal" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Rendre formel" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "フォーマルにする" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "격식체로 변경" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "改为正式语气" } }
+    "Fix capitalization and punctuation": {
+      "comment": "Example prompt value: fix capitalization and punctuation.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Großschreibung und Zeichensetzung korrigieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corregir mayúsculas y puntuación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corriger la casse et la ponctuation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大文字小文字と句読点を修正する"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대소문자와 문장 부호 수정"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "修正大小写和标点符号"
+          }
+        }
       }
     },
-    "No key for %@" : {
-      "comment" : "Footer warning when the active provider has no key. %@ is the provider name.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Kein Schlüssel für %@" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Sin clave para %@" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucune clé pour %@" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%@ のキーがありません" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "%@에 대한 키가 없습니다" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "没有 %@ 的密钥" } }
+    "Get a key": {
+      "comment": "Link to the provider's API key console.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlüssel erhalten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtener una clave"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtenir une clé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーを取得"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키 받기"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "获取密钥"
+          }
+        }
       }
     },
-    "No selection · transforms unavailable, questions still work" : {
-      "comment" : "Steno selection line when nothing is selected.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Keine Auswahl · Transformationen nicht verfügbar, Fragen funktionieren weiterhin" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Sin selección · transformaciones no disponibles, las preguntas siguen funcionando" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucune sélection · transformations indisponibles, les questions fonctionnent toujours" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "選択なし · 変換は利用できません。質問は引き続き使えます" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "선택 없음 · 변환을 사용할 수 없지만 질문은 가능합니다" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "未选择 · 变换不可用，但仍可提问" } }
+    "Key works": {
+      "comment": "Status shown when an API key validates successfully.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlüssel funktioniert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La clave funciona"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La clé fonctionne"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーは有効です"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키가 작동합니다"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "密钥有效"
+          }
+        }
       }
     },
-    "Paste %@…" : {
-      "comment" : "API key field placeholder. %@ is a key-prefix hint like sk-ant.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "%@ einfügen…" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Pega %@…" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Coller %@…" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%@ を貼り付け…" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "%@ 붙여넣기…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "粘贴 %@…" } }
+    "Last answer": {
+      "comment": "Header above the last AI answer card.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte Antwort"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última respuesta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière réponse"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前回の回答"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마지막 답변"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上一个回答"
+          }
+        }
       }
     },
-    "Planning timing…" : {
-      "comment" : "AI routing status: planning the timing pass.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Timing wird geplant…" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Planificando el tiempo…" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Planification du timing…" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "タイミングを計画中…" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "타이밍 계획 중…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "正在规划计时…" } }
+    "Light and fast, any modern Mac": {
+      "comment": "Blurb for the Gemma local model.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leicht und schnell, jeder Mac"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ligero y rápido, cualquier Mac"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Léger et rapide, tout Mac"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "軽量・高速、どの Mac でも"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가볍고 빠름, 모든 Mac"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "轻量快速，任何 Mac"
+          }
+        }
       }
     },
-    "Reading prompt…" : {
-      "comment" : "AI routing status: reading/classifying the prompt.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Eingabe wird gelesen…" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Leyendo la indicación…" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Lecture de la requête…" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "プロンプトを読み取り中…" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "프롬프트 읽는 중…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "正在读取提示…" } }
+    "Loading model…": {
+      "comment": "AI button status while the local model loads into memory.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell wird geladen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando modelo…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement du modèle…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデルを読み込み中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델 로딩 중…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载模型…"
+          }
+        }
       }
     },
-    "Recent" : {
-      "comment" : "Section header above recent prompt chips.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Zuletzt verwendet" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Recientes" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Récents" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "最近" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "최근" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "最近" } }
+    "Local": {
+      "comment": "Provider name for on-device local models.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokal"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로컬"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地"
+          }
+        }
       }
     },
-    "Remove filler words like uh, um, like, you know" : {
-      "comment" : "Example prompt value: strip filler words.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Füllwörter wie ähm, äh, also, weißt du entfernen" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Eliminar muletillas como eh, em, o sea, ya sabes" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Supprimer les mots de remplissage comme euh, hum, genre, tu vois" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "「えー」「あの」「えっと」などのつなぎ言葉を削除する" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "음, 어, 그, 있잖아 같은 군더더기 표현 제거" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "去除「呃、嗯、就是、你知道」之类的填充词" } }
+    "Make formal": {
+      "comment": "Example prompt label: make formal.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formeller machen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hacer formal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rendre formel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォーマルにする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "격식체로 변경"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "改为正式语气"
+          }
+        }
       }
     },
-    "Rewrite in a formal tone" : {
-      "comment" : "Example prompt value: make formal.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "In einem formellen Ton umschreiben" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Reescribir en un tono formal" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Réécrire sur un ton formel" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "フォーマルな口調に書き換える" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "격식 있는 어조로 다시 작성" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "用正式语气重写" } }
+    "No key": {
+      "comment": "Badge next to a provider in the picker that has no stored key.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Schlüssel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin clave"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune clé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーなし"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키 없음"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无密钥"
+          }
+        }
       }
     },
-    "Resolving %@…" : {
-      "comment" : "AI routing status while resolving a lane. %@ is the lane name (plus an optional progress suffix like \" (1/2)\").",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "%@ wird aufgelöst…" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Resolviendo %@…" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Résolution de %@…" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%@ を解決中…" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "%@ 확인 중…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "正在解析 %@…" } }
+    "No key for %@": {
+      "comment": "Footer warning when the active provider has no key. %@ is the provider name.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Schlüssel für %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin clave para %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune clé pour %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ のキーがありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에 대한 키가 없습니다"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有 %@ 的密钥"
+          }
+        }
       }
     },
-    "Run" : {
-      "comment" : "Run button: submit the prompt.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Ausführen" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Ejecutar" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Exécuter" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "実行" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "실행" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "运行" } }
+    "No model": {
+      "comment": "Badge next to the local provider when no model is downloaded.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Modell"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin modelo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun modèle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデルなし"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델 없음"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无模型"
+          }
+        }
       }
     },
-    "Save" : {
-      "comment" : "Button: save the API key.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Speichern" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Guardar" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Enregistrer" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "保存" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "저장" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "保存" } }
+    "No model selected": {
+      "comment": "Warning when the local provider is active but no model is selected.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Modell ausgewählt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ningún modelo seleccionado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun modèle sélectionné"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデルが選択されていません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택된 모델 없음"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未选择模型"
+          }
+        }
       }
     },
-    "Saved - paste to replace" : {
-      "comment" : "API key field placeholder when a key is already stored.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Gespeichert - zum Ersetzen einfügen" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Guardado - pega para reemplazar" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Enregistré - collez pour remplacer" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "保存済み - 貼り付けて置き換え" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "저장됨 - 붙여넣어 교체" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "已保存 - 粘贴以替换" } }
+    "No selection · transforms unavailable, questions still work": {
+      "comment": "Steno selection line when nothing is selected.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Auswahl · Transformationen nicht verfügbar, Fragen funktionieren weiterhin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin selección · transformaciones no disponibles, las preguntas siguen funcionando"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune sélection · transformations indisponibles, les questions fonctionnent toujours"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択なし · 変換は利用できません。質問は引き続き使えます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택 없음 · 변환을 사용할 수 없지만 질문은 가능합니다"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未选择 · 变换不可用，但仍可提问"
+          }
+        }
       }
     },
-    "Strip filler words" : {
-      "comment" : "Example prompt label: strip filler words.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Füllwörter entfernen" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Quitar muletillas" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Supprimer les mots de remplissage" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "つなぎ言葉を削除" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "군더더기 표현 제거" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "去除填充词" } }
+    "On-device models": {
+      "comment": "Header for the local model manager.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle auf dem Gerät"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelos en el dispositivo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modèles sur l'appareil"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバイス上のモデル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기기 내 모델"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设备端模型"
+          }
+        }
       }
     },
-    "Testing connection…" : {
-      "comment" : "Status shown while validating an API key.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Verbindung wird getestet…" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Probando conexión…" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Test de la connexion…" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "接続をテスト中…" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "연결 테스트 중…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "正在测试连接…" } }
+    "Paste %@…": {
+      "comment": "API key field placeholder. %@ is a key-prefix hint like sk-ant.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ einfügen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pega %@…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coller %@…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を貼り付け…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 붙여넣기…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴 %@…"
+          }
+        }
       }
     },
-    "Thinking…" : {
-      "comment" : "Fallback status next to the Run spinner.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Denkt nach…" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Pensando…" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Réflexion…" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "思考中…" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "생각 중…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "思考中…" } }
+    "Planning timing…": {
+      "comment": "AI routing status: planning the timing pass.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timing wird geplant…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Planificando el tiempo…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Planification du timing…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイミングを計画中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "타이밍 계획 중…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在规划计时…"
+          }
+        }
       }
     },
-    "Translate into " : {
-      "comment" : "Example prompt value: translate into (trailing space, user completes the language).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Übersetzen nach " } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Traducir a " } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Traduire en " } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "次の言語に翻訳: " } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "다음으로 번역: " } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "翻译为 " } }
+    "Reading prompt…": {
+      "comment": "AI routing status: reading/classifying the prompt.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingabe wird gelesen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leyendo la indicación…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture de la requête…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロンプトを読み取り中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프롬프트 읽는 중…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在读取提示…"
+          }
+        }
       }
     },
-    "Translate to…" : {
-      "comment" : "Example prompt label: translate to.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Übersetzen nach…" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Traducir a…" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Traduire en…" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "翻訳先…" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "번역 대상…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "翻译为…" } }
+    "Recent": {
+      "comment": "Section header above recent prompt chips.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuletzt verwendet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recientes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Récents"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최근"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近"
+          }
+        }
       }
     },
-    "Working…" : {
-      "comment" : "Tooltip on the AI button while a request is in flight.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Arbeitet…" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Trabajando…" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "En cours…" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "処理中…" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "작업 중…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "处理中…" } }
+    "Recommended": {
+      "comment": "Badge on the hardware-recommended local model.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empfohlen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recomendado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recommandé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "おすすめ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추천"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "推荐"
+          }
+        }
       }
     },
-    "no key" : {
-      "comment" : "Badge next to a provider in the picker that has no stored key.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "kein Schlüssel" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "sin clave" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "aucune clé" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "キーなし" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "키 없음" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "无密钥" } }
+    "Recommended is based on your Mac": {
+      "comment": "Hint that the recommendation is hardware-based.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empfehlung basiert auf deinem Mac"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La recomendación se basa en tu Mac"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La recommandation dépend de votre Mac"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "おすすめはお使いの Mac に基づきます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추천은 사용 중인 Mac을 기준으로 합니다"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "推荐基于你的 Mac"
+          }
+        }
+      }
+    },
+    "Remove filler words like uh, um, like, you know": {
+      "comment": "Example prompt value: strip filler words.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füllwörter wie ähm, äh, also, weißt du entfernen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar muletillas como eh, em, o sea, ya sabes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer les mots de remplissage comme euh, hum, genre, tu vois"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「えー」「あの」「えっと」などのつなぎ言葉を削除する"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음, 어, 그, 있잖아 같은 군더더기 표현 제거"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "去除「呃、嗯、就是、你知道」之类的填充词"
+          }
+        }
+      }
+    },
+    "Resolving %@…": {
+      "comment": "AI routing status while resolving a lane. %@ is the lane name (plus an optional progress suffix like \" (1/2)\").",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wird aufgelöst…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resolviendo %@…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Résolution de %@…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を解決中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 확인 중…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在解析 %@…"
+          }
+        }
+      }
+    },
+    "Rewrite in a formal tone": {
+      "comment": "Example prompt value: make formal.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In einem formellen Ton umschreiben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reescribir en un tono formal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réécrire sur un ton formel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォーマルな口調に書き換える"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "격식 있는 어조로 다시 작성"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用正式语气重写"
+          }
+        }
+      }
+    },
+    "Run": {
+      "comment": "Run button: submit the prompt.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausführen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécuter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行"
+          }
+        }
+      }
+    },
+    "Runs entirely on your Mac.": {
+      "comment": "Short footnote in the local model manager.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läuft vollständig auf deinem Mac."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se ejecuta por completo en tu Mac."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonctionne entièrement sur votre Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてお使いの Mac 上で動作します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전적으로 Mac에서 실행됩니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全在你的 Mac 上运行。"
+          }
+        }
+      }
+    },
+    "Save": {
+      "comment": "Button: save the API key.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
+    "Saved - paste to replace": {
+      "comment": "API key field placeholder when a key is already stored.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gespeichert - zum Ersetzen einfügen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardado - pega para reemplazar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistré - collez pour remplacer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存済み - 貼り付けて置き換え"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장됨 - 붙여넣어 교체"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已保存 - 粘贴以替换"
+          }
+        }
+      }
+    },
+    "Strip filler words": {
+      "comment": "Example prompt label: strip filler words.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füllwörter entfernen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar muletillas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer les mots de remplissage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "つなぎ言葉を削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "군더더기 표현 제거"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "去除填充词"
+          }
+        }
+      }
+    },
+    "Strong reasoning, needs 16 GB": {
+      "comment": "Blurb for the Qwen local model.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starkes Reasoning, braucht 16 GB"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Razonamiento potente, necesita 16 GB"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raisonnement solide, 16 Go requis"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高い推論、16 GB 必要"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "강력한 추론, 16 GB 필요"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "强大推理，需要 16 GB"
+          }
+        }
+      }
+    },
+    "Strongest reasoning, needs 16 GB": {
+      "comment": "Blurb for the Qwen local model.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stärkstes Reasoning, braucht 16 GB"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máximo razonamiento, necesita 16 GB"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raisonnement maximal, 16 Go requis"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最高の推論、16 GB 必要"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최고 추론, 16 GB 필요"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最强推理，需要 16 GB"
+          }
+        }
+      }
+    },
+    "Testing connection…": {
+      "comment": "Status shown while validating an API key.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung wird getestet…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Probando conexión…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test de la connexion…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続をテスト中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결 테스트 중…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在测试连接…"
+          }
+        }
+      }
+    },
+    "Thinking…": {
+      "comment": "Fallback status next to the Run spinner.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denkt nach…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pensando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réflexion…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "思考中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "생각 중…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "思考中…"
+          }
+        }
+      }
+    },
+    "Translate into ": {
+      "comment": "Example prompt value: translate into (trailing space, user completes the language).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Übersetzen nach "
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traducir a "
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traduire en "
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次の言語に翻訳: "
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음으로 번역: "
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "翻译为 "
+          }
+        }
+      }
+    },
+    "Translate to…": {
+      "comment": "Example prompt label: translate to.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Übersetzen nach…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traducir a…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traduire en…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "翻訳先…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "번역 대상…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "翻译为…"
+          }
+        }
+      }
+    },
+    "Uninstall": {
+      "comment": "Context-menu action to remove a downloaded local model.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désinstaller"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アンインストール"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제거"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "卸载"
+          }
+        }
+      }
+    },
+    "Working…": {
+      "comment": "Tooltip on the AI button while a request is in flight.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeitet…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trabajando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En cours…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "処理中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 중…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "处理中…"
+          }
+        }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/KeyframelessAI/Sources/KeyframelessAI/Resources/Localizable.xcstrings
+++ b/KeyframelessAI/Sources/KeyframelessAI/Resources/Localizable.xcstrings
@@ -1094,44 +1094,44 @@
         }
       }
     },
-    "Loading model…" : {
+    "Loading model" : {
       "comment" : "AI button status while the local model loads into memory.",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Modell wird geladen…"
+            "value" : "Modell wird geladen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cargando modelo…"
+            "value" : "Cargando modelo"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Chargement du modèle…"
+            "value" : "Chargement du modèle"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "モデルを読み込み中…"
+            "value" : "モデルを読み込み中"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "모델 로딩 중…"
+            "value" : "모델 로딩 중"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在加载模型…"
+            "value" : "正在加载模型"
           }
         }
       }
@@ -1514,86 +1514,86 @@
         }
       }
     },
-    "Planning timing…" : {
+    "Planning timing" : {
       "comment" : "AI routing status: planning the timing pass.",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Timing wird geplant…"
+            "value" : "Timing wird geplant"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Planificando el tiempo…"
+            "value" : "Planificando el tiempo"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Planification du timing…"
+            "value" : "Planification du timing"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "タイミングを計画中…"
+            "value" : "タイミングを計画中"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "타이밍 계획 중…"
+            "value" : "타이밍 계획 중"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在规划计时…"
+            "value" : "正在规划计时"
           }
         }
       }
     },
-    "Reading prompt…" : {
+    "Reading prompt" : {
       "comment" : "AI routing status: reading/classifying the prompt.",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Eingabe wird gelesen…"
+            "value" : "Eingabe wird gelesen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Leyendo la indicación…"
+            "value" : "Leyendo la indicación"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lecture de la requête…"
+            "value" : "Lecture de la requête"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "プロンプトを読み取り中…"
+            "value" : "プロンプトを読み取り中"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "프롬프트 읽는 중…"
+            "value" : "프롬프트 읽는 중"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在读取提示…"
+            "value" : "正在读取提示"
           }
         }
       }
@@ -1765,6 +1765,9 @@
           }
         }
       }
+    },
+    "Resolving %@" : {
+
     },
     "Resolving %@…" : {
       "comment" : "AI routing status while resolving a lane. %@ is the lane name (plus an optional progress suffix like \" (1/2)\").",
@@ -2142,86 +2145,86 @@
         }
       }
     },
-    "Testing connection…" : {
+    "Testing connection" : {
       "comment" : "Status shown while validating an API key.",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verbindung wird getestet…"
+            "value" : "Verbindung wird getestet"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Probando conexión…"
+            "value" : "Probando conexión"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Test de la connexion…"
+            "value" : "Test de la connexion"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "接続をテスト中…"
+            "value" : "接続をテスト中"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "연결 테스트 중…"
+            "value" : "연결 테스트 중"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在测试连接…"
+            "value" : "正在测试连接"
           }
         }
       }
     },
-    "Thinking…" : {
+    "Thinking" : {
       "comment" : "Fallback status next to the Run spinner.",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Denkt nach…"
+            "value" : "Denkt nach"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pensando…"
+            "value" : "Pensando"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Réflexion…"
+            "value" : "Réflexion"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "思考中…"
+            "value" : "思考中"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "생각 중…"
+            "value" : "생각 중"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "思考中…"
+            "value" : "思考中"
           }
         }
       }
@@ -2352,44 +2355,44 @@
         }
       }
     },
-    "Working…" : {
+    "Working" : {
       "comment" : "Tooltip on the AI button while a request is in flight.",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Arbeitet…"
+            "value" : "Arbeitet"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Trabajando…"
+            "value" : "Trabajando"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "En cours…"
+            "value" : "En cours"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "処理中…"
+            "value" : "処理中"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "작업 중…"
+            "value" : "작업 중"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "处理中…"
+            "value" : "处理中"
           }
         }
       }

--- a/KeyframelessAI/Sources/KeyframelessAI/State/AIRecentPrompts.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/State/AIRecentPrompts.swift
@@ -12,7 +12,7 @@ public final class AIRecentPrompts: ObservableObject {
 
 	@Published public private(set) var prompts: [String] = []
 
-	private static let key = "com.overpolish.ai.recentPrompts"
+	private static let key = "co.overpolish.ai.recentPrompts"
 	private static let maxCount = 5
 
 	private init() {

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/AIActionTab.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/AIActionTab.swift
@@ -63,7 +63,7 @@ struct AIActionTab: View {
 					.foregroundStyle(Color.accentColor)
 				Text(AILoc("Last answer"))
 					.font(.system(size: 10, weight: .semibold))
-					.foregroundStyle(.secondary)
+					.foregroundStyle(Color.aiSecondaryText)
 					.textCase(.uppercase)
 				Spacer()
 				Button {
@@ -71,7 +71,7 @@ struct AIActionTab: View {
 				} label: {
 					Image(systemName: "xmark")
 						.font(.system(size: 9, weight: .medium))
-						.foregroundStyle(.secondary)
+						.foregroundStyle(Color.aiSecondaryText)
 				}
 				.buttonStyle(.plain)
 				.help(AILoc("Dismiss answer"))
@@ -107,7 +107,7 @@ struct AIActionTab: View {
 					: AILoc("No selection · transforms unavailable, questions still work")
 			)
 			.font(.system(size: 11))
-			.foregroundStyle(.secondary)
+			.foregroundStyle(Color.aiSecondaryText)
 		}
 	}
 
@@ -128,7 +128,7 @@ struct AIActionTab: View {
 		VStack(alignment: .leading, spacing: 4) {
 			Text(AILoc("Examples"))
 				.font(.system(size: 10, weight: .semibold))
-				.foregroundStyle(.tertiary)
+				.foregroundStyle(Color.aiTertiaryText)
 				.textCase(.uppercase)
 			FlowLayout(spacing: 4) {
 				ForEach(examples, id: \.label) { ex in
@@ -155,7 +155,7 @@ struct AIActionTab: View {
 		VStack(alignment: .leading, spacing: 4) {
 			Text(AILoc("Recent"))
 				.font(.system(size: 10, weight: .semibold))
-				.foregroundStyle(.tertiary)
+				.foregroundStyle(Color.aiTertiaryText)
 				.textCase(.uppercase)
 			FlowLayout(spacing: 4) {
 				ForEach(recents.prompts, id: \.self) { p in
@@ -173,7 +173,7 @@ struct AIActionTab: View {
 							.background(
 								Capsule().strokeBorder(Color.white.opacity(0.12))
 							)
-							.foregroundStyle(.secondary)
+							.foregroundStyle(Color.aiSecondaryText)
 					}
 					.buttonStyle(.plain)
 				}
@@ -189,7 +189,9 @@ struct AIActionTab: View {
 		return HStack(spacing: 8) {
 			if !keyState.activeIsConfigured {
 				Label(
-					AILoc("No key for \(keyState.activeProvider.displayName)"),
+					keyState.activeProvider.requiresAPIKey
+						? AILoc("No key for \(keyState.activeProvider.displayName)")
+						: AILoc("No model selected"),
 					systemImage: "exclamationmark.triangle.fill"
 				)
 				.font(.system(size: 10))

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/AIActionTab.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/AIActionTab.swift
@@ -204,7 +204,7 @@ struct AIActionTab: View {
 				if draft.isRouting {
 					HStack(spacing: 4) {
 						ProgressView().controlSize(.small)
-						Text(draft.routingStatus ?? AILoc("Thinking…"))
+						Text(draft.routingStatus ?? AILoc("Thinking"))
 					}
 				} else if isDone {
 					Label(AILoc("Done"), systemImage: "checkmark")
@@ -235,17 +235,27 @@ struct AIActionTab: View {
 		}
 
 		draft.isRouting = true
+		draft.pendingAnswer = nil
 		let captured = (selectedCount, productContext, trimmed)
 		Task { @MainActor in
 			do {
-				let intent = try await AIRouter.route(
+				let intent = try await AIRouter.routeStreaming(
 					captured.2,
 					selectedCount: captured.0,
 					productContext: captured.1
-				)
+				) { partial in
+					// First answer token arrived: drop the spinner, reveal the answer
+					// card, and keep filling it as tokens stream in. (A transform never
+					// calls this - it stays a spinner until its preview popover opens.)
+					draft.isRouting = false
+					draft.didAnswerQuestion = true
+					draft.pendingAnswer = partial
+				}
+				// Record both questions and transforms in recents (the plugin branch
+				// above records unconditionally too); only a thrown route skips it.
+				recents.record(captured.2)
 				switch intent {
 				case .transform(let cleanInstruction):
-					recents.record(captured.2)
 					draft.prompt = ""
 					// Keep the icon animating right up until the host puts its
 					// transform preview popover on screen - onRun opens it, so

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/AIButton.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/AIButton.swift
@@ -44,7 +44,7 @@ public struct AIButton: View {
 	private var helpText: String {
 		switch iconState {
 		case .unconfigured: return AILoc("Configure AI key")
-		case .running: return AILoc("Working…")
+		case .running: return AILoc("Working")
 		case .done: return AILoc("Done - click to review")
 		case .idle: return AILoc("AI")
 		}

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/AIConfigTab.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/AIConfigTab.swift
@@ -79,7 +79,7 @@ struct AIConfigTab: View {
 		case .idle:
 			EmptyView()
 		case .validating:
-			Label(AILoc("Testing connection…"), systemImage: "ellipsis.circle")
+			Label(AILoc("Testing connection"), systemImage: "ellipsis.circle")
 				.font(.caption)
 				.foregroundStyle(Color.aiSecondaryText)
 		case .success:

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/AIConfigTab.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/AIConfigTab.swift
@@ -21,15 +21,23 @@ struct AIConfigTab: View {
 	private var provider: AIProvider { keyState.activeProvider }
 
 	var body: some View {
+		if provider == .local {
+			LocalModelsView()
+		} else {
+			keyEntryForm
+		}
+	}
+
+	private var keyEntryForm: some View {
 		VStack(alignment: .leading, spacing: 12) {
 			HStack(spacing: 8) {
 				Text(AILoc("API Key"))
 					.font(.system(size: 12, weight: .medium))
-					.foregroundStyle(.secondary)
+					.foregroundStyle(Color.aiSecondaryText)
 				SecureField(
 					savedKeyExists
 						? AILoc("Saved - paste to replace")
-						: AILoc("Paste \(provider.keyPrefixHint)…"),
+						: AILoc("Paste \(provider.keyPrefixHint ?? "")…"),
 					text: $keyInput
 				)
 				.textFieldStyle(.roundedBorder)
@@ -39,8 +47,10 @@ struct AIConfigTab: View {
 			statusLine
 
 			HStack {
-				Link(AILoc("Get a key"), destination: provider.keyConsoleURL)
-					.font(.caption)
+				if let consoleURL = provider.keyConsoleURL {
+					Link(AILoc("Get a key"), destination: consoleURL)
+						.font(.caption)
+				}
 				Spacer()
 				if savedKeyExists {
 					Button(AILoc("Delete"), role: .destructive) { delete() }
@@ -71,7 +81,7 @@ struct AIConfigTab: View {
 		case .validating:
 			Label(AILoc("Testing connection…"), systemImage: "ellipsis.circle")
 				.font(.caption)
-				.foregroundStyle(.secondary)
+				.foregroundStyle(Color.aiSecondaryText)
 		case .success:
 			Label(AILoc("Key works"), systemImage: "checkmark.circle.fill")
 				.font(.caption)

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/AIPillBadge.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/AIPillBadge.swift
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import SwiftUI
+
+/// Small filled-capsule badge. Mirrors Keyframeless X's `InfoBadge` (the style
+/// used by the interactive guides and Steno's model picker) so badges look the
+/// same everywhere. This package can't depend on KeyframelessKit, so the token
+/// values are inlined.
+struct AIPillBadge: View {
+	let label: String
+	var systemImage: String? = nil
+	var color: Color = .secondary
+
+	var body: some View {
+		HStack(spacing: 3) {
+			if let systemImage {
+				Image(systemName: systemImage)
+					.font(.system(size: 8))
+			}
+			Text(label)
+				.font(.system(size: 9, weight: .medium))
+				.lineLimit(1)
+		}
+		.foregroundStyle(color)
+		.padding(.horizontal, 5)
+		.padding(.vertical, 2)
+		.background(Capsule().fill(color.opacity(0.15)))
+		.fixedSize()
+	}
+}

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/AIProviderLogo.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/AIProviderLogo.swift
@@ -13,17 +13,27 @@ public struct AIProviderLogo: View {
 	}
 
 	public var body: some View {
-		Image(imageName, bundle: .module)
-			.resizable()
-			.renderingMode(.template)
-			.scaledToFit()
-			.foregroundStyle(.primary)
+		// The local provider has no brand asset; render an SF Symbol instead of
+		// a bundled template image.
+		if provider == .local {
+			Image(systemName: "desktopcomputer")
+				.resizable()
+				.scaledToFit()
+				.foregroundStyle(.primary)
+		} else {
+			Image(imageName, bundle: .module)
+				.resizable()
+				.renderingMode(.template)
+				.scaledToFit()
+				.foregroundStyle(.primary)
+		}
 	}
 
 	private var imageName: String {
 		switch provider {
 		case .anthropic: return "logo-anthropic"
 		case .openai: return "logo-openai"
+		case .local: return ""
 		}
 	}
 }

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/AISettingsPopover.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/AISettingsPopover.swift
@@ -50,7 +50,7 @@ public struct AISettingsPopover: View {
 		self.isPluginMode = isPluginMode
 		self.onRun = onRun
 		self.onDismiss = onDismiss
-		let initial: Tab = AIKeyState.shared.hasAnyKey ? .action : .config
+		let initial: Tab = AIKeyState.shared.activeIsConfigured ? .action : .config
 		_tab = State(initialValue: initial)
 	}
 
@@ -59,7 +59,14 @@ public struct AISettingsPopover: View {
 			HStack(spacing: 8) {
 				tabBar
 				Spacer(minLength: 0)
-				SharedProviderPicker()
+				SharedProviderPicker { picked in
+					// Picking a provider that isn't set up yet (cloud with no
+					// key, or local with no model) drops the user on Config so
+					// they can finish setup.
+					if !keyState.configuredProviders.contains(picked) {
+						tab = .config
+					}
+				}
 			}
 			.padding(.horizontal, 12)
 			.padding(.top, 10)
@@ -84,7 +91,7 @@ public struct AISettingsPopover: View {
 			}
 			.padding(14)
 		}
-		.frame(width: 360)
+		.frame(width: 380)
 		.fixedSize(horizontal: false, vertical: true)
 		.animation(.easeInOut(duration: 0.18), value: tab)
 		.popoverGlassFix()
@@ -97,7 +104,9 @@ public struct AISettingsPopover: View {
 		HStack(spacing: 4) {
 			ForEach(Tab.allCases) { t in
 				let isSelected = tab == t
-				let isDisabled = (t == .action && !keyState.hasAnyKey)
+				// Action is unusable until the ACTIVE provider can actually run
+				// (cloud key present, or a local model downloaded + selected).
+				let isDisabled = (t == .action && !keyState.activeIsConfigured)
 				Button {
 					tab = t
 				} label: {
@@ -114,7 +123,7 @@ public struct AISettingsPopover: View {
 							Capsule().fill(Color.accentColor)
 						}
 					}
-					.foregroundStyle(isSelected ? Color.white : .secondary)
+					.foregroundStyle(isSelected ? Color.white : Color.aiSecondaryText)
 					.contentShape(Capsule())
 					.opacity(isDisabled ? 0.35 : 1)
 				}
@@ -128,6 +137,7 @@ public struct AISettingsPopover: View {
 struct SharedProviderPicker: View {
 	@StateObject private var keyState = AIKeyState.shared
 	@State private var showMenu = false
+	var onPick: (AIProvider) -> Void = { _ in }
 
 	var body: some View {
 		Button {
@@ -140,22 +150,23 @@ struct SharedProviderPicker: View {
 					.font(.system(size: 11, weight: .medium))
 				Image(systemName: "chevron.up.chevron.down")
 					.font(.system(size: 8))
-					.foregroundStyle(.tertiary)
+					.foregroundStyle(Color.aiTertiaryText)
 			}
 			.padding(.horizontal, 8)
 			.padding(.vertical, 4)
 			.background(Capsule().fill(Color.white.opacity(0.08)))
-			.foregroundStyle(.secondary)
+			.foregroundStyle(Color.aiSecondaryText)
 			.contentShape(Capsule())
 		}
 		.buttonStyle(.plain)
 		.popover(isPresented: $showMenu, arrowEdge: .bottom) {
 			VStack(alignment: .leading, spacing: 2) {
-				ForEach(AIProvider.allCases) { p in
+				ForEach(AIProvider.availableCases) { p in
 					let configured = keyState.configuredProviders.contains(p)
 					Button {
 						keyState.activeProvider = p
 						showMenu = false
+						onPick(p)
 					} label: {
 						HStack(spacing: 8) {
 							AIProviderLogo(provider: p)
@@ -163,12 +174,8 @@ struct SharedProviderPicker: View {
 							Text(p.displayName)
 								.font(.system(size: 12))
 							if !configured {
-								Text(AILoc("no key"))
-									.font(.system(size: 9))
-									.foregroundStyle(.tertiary)
-									.padding(.horizontal, 5)
-									.padding(.vertical, 1)
-									.background(Capsule().strokeBorder(Color.white.opacity(0.12)))
+								AIPillBadge(
+									label: p.requiresAPIKey ? AILoc("No key") : AILoc("No model"))
 							}
 							Spacer()
 							if p == keyState.activeProvider {

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/AITextColors.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/AITextColors.swift
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import SwiftUI
+
+extension Color {
+	/// Legible stand-ins for `.secondary` / `.tertiary`, which wash out to near-
+	/// invisible on the liquid-glass popover background. Opacity-on-primary keeps
+	/// real contrast in both light and dark.
+	static let aiSecondaryText = Color.primary.opacity(0.75)
+	static let aiTertiaryText = Color.primary.opacity(0.55)
+}

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/LocalModelsView.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/LocalModelsView.swift
@@ -63,34 +63,54 @@ private struct LocalModelRow: View {
 				.frame(width: 6, height: 6)
 
 			VStack(alignment: .leading, spacing: 1) {
-				HStack(spacing: 6) {
-					Text(model.displayName)
-						.font(.system(size: 12, weight: isSelected ? .medium : .regular))
-						.foregroundStyle(isDownloaded ? Color.primary : Color.aiSecondaryText)
+				Text(model.displayName)
+					.font(.system(size: 12, weight: isSelected ? .medium : .regular))
+					.foregroundStyle(isDownloaded ? Color.primary : Color.aiSecondaryText)
+					.lineLimit(1)
+					.truncationMode(.tail)
+				Text(model.blurb)
+					.font(.system(size: 10))
+					.foregroundStyle(Color.aiSecondaryText)
+					.lineLimit(1)
+					.truncationMode(.tail)
+			}
+			.layoutPriority(1)
+
+			Spacer(minLength: 8)
+
+			if isDownloading {
+				// Downloading: progress ONLY. The fixed-size badges + the progress
+				// bar together overflow the row and collapse the (flexible) title,
+				// so we drop the badges here - the title keeps its space.
+				DownloadProgress(progress: store.downloadProgress, accent: accent) {
+					store.cancelDownload()
+				}
+			} else {
+				// Right-aligned badges, STACKED: "Recommended" on its own row above
+				// the size+RAM row. Three pills side-by-side are too wide and
+				// truncate the title/blurb; stacking halves the right-column width.
+				// Size + RAM are neutral (gray) badges (the gray matches the guide's
+				// "completed" chip); the green "Recommended" only shows on the
+				// best-fit model. Distinct icons disambiguate disk vs memory.
+				VStack(alignment: .trailing, spacing: 3) {
 					if model.id == LocalModelCatalog.recommendedModelID {
 						AIPillBadge(
 							label: AILoc("Recommended"),
 							systemImage: "desktopcomputer", color: .green)
 					}
-					Text(model.sizeDescription)
-						.font(.system(size: 10))
-						.foregroundStyle(Color.aiTertiaryText)
+					HStack(spacing: 4) {
+						AIPillBadge(
+							label: model.sizeDescription,
+							systemImage: "internaldrive", color: .secondary)
+						AIPillBadge(
+							label: "\(model.minRAMGB) GB",
+							systemImage: "memorychip", color: .secondary)
+					}
 				}
-				Text(model.blurb)
-					.font(.system(size: 10))
-					.foregroundStyle(Color.aiSecondaryText)
-					.fixedSize(horizontal: false, vertical: true)
-			}
-
-			Spacer(minLength: 8)
-
-			if isDownloading {
-				DownloadProgress(progress: store.downloadProgress, accent: accent) {
-					store.cancelDownload()
-				}
-			} else if !isDownloaded {
-				DownloadButton(accent: accent, disabled: store.downloadingModel != nil) {
-					Task { await store.download(model.id) }
+				if !isDownloaded {
+					DownloadButton(accent: accent, disabled: store.downloadingModel != nil) {
+						Task { await store.download(model.id) }
+					}
 				}
 			}
 		}
@@ -151,9 +171,11 @@ private struct DownloadButton: View {
 			HStack(spacing: 3) {
 				Image(systemName: "arrow.down.circle")
 				Text(AILoc("Download"))
+					.lineLimit(1)
 			}
 			.font(.system(size: 10))
 			.foregroundStyle(disabled ? Color.secondary : accent)
+			.fixedSize()
 		}
 		.buttonStyle(.plain)
 		.disabled(disabled)

--- a/KeyframelessAI/Sources/KeyframelessAI/UI/LocalModelsView.swift
+++ b/KeyframelessAI/Sources/KeyframelessAI/UI/LocalModelsView.swift
@@ -1,0 +1,161 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import SwiftUI
+
+/// Config-tab view for the Local provider: download, select and manage the
+/// on-device models. Mirrors Steno's model picker (selection dot, name,
+/// Recommended badge, size, blurb, download/progress) but in plain SwiftUI -
+/// this package has no KeyframelessKit dependency.
+struct LocalModelsView: View {
+	@StateObject private var store = LocalModelStore.shared
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 10) {
+			HStack(alignment: .firstTextBaseline) {
+				Text(AILoc("On-device models"))
+					.font(.system(size: 12, weight: .medium))
+					.foregroundStyle(Color.aiSecondaryText)
+				Spacer()
+				Text(AILoc("Recommended is based on your Mac"))
+					.font(.system(size: 9))
+					.foregroundStyle(Color.aiTertiaryText)
+			}
+
+			VStack(alignment: .leading, spacing: 2) {
+				ForEach(LocalModelCatalog.models) { model in
+					LocalModelRow(model: model, store: store)
+				}
+			}
+
+			if let err = store.lastError {
+				Text(err)
+					.font(.system(size: 9))
+					.foregroundStyle(.red)
+					.fixedSize(horizontal: false, vertical: true)
+					.textSelection(.enabled)
+			}
+
+			Text(AILoc("Runs entirely on your Mac."))
+				.font(.system(size: 9))
+				.foregroundStyle(Color.aiTertiaryText)
+				.fixedSize(horizontal: false, vertical: true)
+		}
+		.onAppear { store.refreshDownloaded() }
+	}
+}
+
+private struct LocalModelRow: View {
+	let model: LocalAIModel
+	@ObservedObject var store: LocalModelStore
+
+	var body: some View {
+		let isDownloaded = store.downloadedModels.contains(model.id)
+		let isDownloading = store.downloadingModel == model.id
+		let isSelected = store.selectedModelID == model.id
+		let accent = Color.accentColor
+
+		HStack(spacing: 10) {
+			Circle()
+				.fill(isSelected ? accent : Color.secondary.opacity(0.3))
+				.frame(width: 6, height: 6)
+
+			VStack(alignment: .leading, spacing: 1) {
+				HStack(spacing: 6) {
+					Text(model.displayName)
+						.font(.system(size: 12, weight: isSelected ? .medium : .regular))
+						.foregroundStyle(isDownloaded ? Color.primary : Color.aiSecondaryText)
+					if model.id == LocalModelCatalog.recommendedModelID {
+						AIPillBadge(
+							label: AILoc("Recommended"),
+							systemImage: "desktopcomputer", color: .green)
+					}
+					Text(model.sizeDescription)
+						.font(.system(size: 10))
+						.foregroundStyle(Color.aiTertiaryText)
+				}
+				Text(model.blurb)
+					.font(.system(size: 10))
+					.foregroundStyle(Color.aiSecondaryText)
+					.fixedSize(horizontal: false, vertical: true)
+			}
+
+			Spacer(minLength: 8)
+
+			if isDownloading {
+				DownloadProgress(progress: store.downloadProgress, accent: accent) {
+					store.cancelDownload()
+				}
+			} else if !isDownloaded {
+				DownloadButton(accent: accent, disabled: store.downloadingModel != nil) {
+					Task { await store.download(model.id) }
+				}
+			}
+		}
+		.padding(.horizontal, 8)
+		.padding(.vertical, 7)
+		.background {
+			RoundedRectangle(cornerRadius: 6)
+				.fill(isSelected ? accent.opacity(0.10) : Color.clear)
+		}
+		.contentShape(Rectangle())
+		.onTapGesture {
+			if isDownloaded { store.select(model.id) }
+		}
+		.contextMenu {
+			if isDownloaded {
+				Button(role: .destructive) {
+					store.uninstall(model.id)
+				} label: {
+					Label(AILoc("Uninstall"), systemImage: "trash")
+				}
+			}
+		}
+	}
+}
+
+private struct DownloadProgress: View {
+	let progress: Double
+	let accent: Color
+	let onCancel: () -> Void
+
+	var body: some View {
+		HStack(spacing: 5) {
+			ProgressView(value: progress)
+				.progressViewStyle(.linear)
+				.tint(accent)
+				.frame(width: 56)
+			Text("\(Int(progress * 100))%")
+				.font(.system(size: 9))
+				.foregroundStyle(Color.aiSecondaryText)
+				.monospacedDigit()
+			Button(action: onCancel) {
+				Image(systemName: "xmark.circle.fill")
+					.font(.system(size: 11))
+					.foregroundStyle(Color.aiTertiaryText)
+			}
+			.buttonStyle(.plain)
+		}
+	}
+}
+
+private struct DownloadButton: View {
+	let accent: Color
+	let disabled: Bool
+	let action: () -> Void
+
+	var body: some View {
+		Button(action: action) {
+			HStack(spacing: 3) {
+				Image(systemName: "arrow.down.circle")
+				Text(AILoc("Download"))
+			}
+			.font(.system(size: 10))
+			.foregroundStyle(disabled ? Color.secondary : accent)
+		}
+		.buttonStyle(.plain)
+		.disabled(disabled)
+	}
+}

--- a/KeyframelessKit/KeyframelessKit/Views/Controls/Containers/KKReorderListView.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Controls/Containers/KKReorderListView.m
@@ -11,7 +11,7 @@
 // layer-list reorder, which archives an NSIndexSet; a single int suffices here
 // since the property list is single-select).
 static NSString *const kKKReorderDragType =
-    @"com.overpolish.keyframeless.reorderRow";
+    @"co.overpolish.keyframeless.reorderRow";
 
 static const CGFloat kRowH = 28.0;
 static const CGFloat kRowGap = 2.0;

--- a/KeyframelessKit/KeyframelessKit/Views/Joyride/Bridge/KKOSCGuideBridge.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Joyride/Bridge/KKOSCGuideBridge.m
@@ -53,11 +53,11 @@
 }
 
 - (NSNotificationName)guideStepNotificationName {
-  return @"com.overpolish.kk.oscGuideStep";
+  return @"co.overpolish.kk.oscGuideStep";
 }
 
 - (NSNotificationName)guidePositionNotificationName {
-  return @"com.overpolish.kk.oscGuidePosition";
+  return @"co.overpolish.kk.oscGuidePosition";
 }
 
 - (NSInteger)guideStep {

--- a/KeyframelessKit/KeyframelessKit/Views/Timeline/KKKeyposeClipboard.m
+++ b/KeyframelessKit/KeyframelessKit/Views/Timeline/KKKeyposeClipboard.m
@@ -9,7 +9,7 @@
 #import <KeyframelessKit/KKTimingStage.h>
 
 static NSString *const kKKKeyposePBType =
-    @"com.overpolish.keyframeless.keyposeValues";
+    @"co.overpolish.keyframeless.keyposeValues";
 static NSInteger const kKKKeyposePBVersion = 1;
 
 @interface KKKeyposeClipboardEntry ()

--- a/MagicMove/MagicMove.xcodeproj/project.pbxproj
+++ b/MagicMove/MagicMove.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		AA0000000000000000000001 /* KeyframelessAI in Frameworks */ = {isa = PBXBuildFile; productRef = AA0000000000000000000002 /* KeyframelessAI */; };
+		F20AACA22FD7203B0032F7FF /* KeyframelessAI in Frameworks */ = {isa = PBXBuildFile; productRef = F20AACA12FD7203B0032F7FF /* KeyframelessAI */; };
+		F20AACA62FD7205B0032F7FF /* kk-ai-helper in CopyFiles */ = {isa = PBXBuildFile; fileRef = F20AAC9A2FD720220032F7FF /* kk-ai-helper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F21396022F649EF900E1EC03 /* keyframeless.icon in Resources */ = {isa = PBXBuildFile; fileRef = F21396012F649EF900E1EC03 /* keyframeless.icon */; };
 		F21396032F649EF900E1EC03 /* keyframeless.icon in Resources */ = {isa = PBXBuildFile; fileRef = F21396012F649EF900E1EC03 /* keyframeless.icon */; };
 		F220BFE32F4E07EB0034AF77 /* KeyframelessKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F26E024E2F4DE56D009D949A /* KeyframelessKit.framework */; };
@@ -24,6 +26,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		F20AACA32FD720480032F7FF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F2E2ED6D2F4CA530008620D9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F20AAC992FD720220032F7FF;
+			remoteInfo = "kk-ai-helper";
+		};
 		F2E2ED822F4CA530008620D9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F2E2ED6D2F4CA530008620D9 /* Project object */;
@@ -41,6 +50,25 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		F20AAC982FD720220032F7FF /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		F20AACA52FD720500032F7FF /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 6;
+			files = (
+				F20AACA62FD7205B0032F7FF /* kk-ai-helper in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F220BFE52F4E07EC0034AF77 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -77,6 +105,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F20AAC9A2FD720220032F7FF /* kk-ai-helper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "kk-ai-helper"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F20AACA72FD720850032F7FF /* Wrapper ApplicationRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Wrapper ApplicationRelease.entitlements"; sourceTree = "<group>"; };
 		F21396012F649EF900E1EC03 /* keyframeless.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; name = keyframeless.icon; path = ../Assets/keyframeless.icon; sourceTree = SOURCE_ROOT; };
 		F26E024E2F4DE56D009D949A /* KeyframelessKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = KeyframelessKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2E2ED752F4CA530008620D9 /* MagicMove.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MagicMove.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -129,6 +159,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		F20AAC9B2FD720220032F7FF /* kk-ai-helper */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "kk-ai-helper";
+			sourceTree = "<group>";
+		};
 		F2E2ED902F4CA530008620D9 /* MagicMove */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -141,6 +176,14 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		F20AAC972FD720220032F7FF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F20AACA22FD7203B0032F7FF /* KeyframelessAI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F2E2ED722F4CA530008620D9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -170,8 +213,10 @@
 		F2E2ED6C2F4CA530008620D9 = {
 			isa = PBXGroup;
 			children = (
+				F20AACA72FD720850032F7FF /* Wrapper ApplicationRelease.entitlements */,
 				F21396012F649EF900E1EC03 /* keyframeless.icon */,
 				F2E2ED902F4CA530008620D9 /* MagicMove */,
+				F20AAC9B2FD720220032F7FF /* kk-ai-helper */,
 				F2E2ED772F4CA530008620D9 /* Frameworks */,
 				F2E2ED762F4CA530008620D9 /* Products */,
 			);
@@ -182,6 +227,7 @@
 			children = (
 				F2E2ED752F4CA530008620D9 /* MagicMove.app */,
 				F2E2ED802F4CA530008620D9 /* MagicMove XPC Service.pluginkit */,
+				F20AAC9A2FD720220032F7FF /* kk-ai-helper */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -203,6 +249,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		F20AAC992FD720220032F7FF /* kk-ai-helper */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F20AACA02FD720220032F7FF /* Build configuration list for PBXNativeTarget "kk-ai-helper" */;
+			buildPhases = (
+				F20AAC962FD720220032F7FF /* Sources */,
+				F20AAC972FD720220032F7FF /* Frameworks */,
+				F20AAC982FD720220032F7FF /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F20AAC9B2FD720220032F7FF /* kk-ai-helper */,
+			);
+			name = "kk-ai-helper";
+			packageProductDependencies = (
+				F20AACA12FD7203B0032F7FF /* KeyframelessAI */,
+			);
+			productName = "kk-ai-helper";
+			productReference = F20AAC9A2FD720220032F7FF /* kk-ai-helper */;
+			productType = "com.apple.product-type.tool";
+		};
 		F2E2ED742F4CA530008620D9 /* Wrapper Application */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F2E2EDBA2F4CA530008620D9 /* Build configuration list for PBXNativeTarget "Wrapper Application" */;
@@ -239,10 +308,12 @@
 				F2E2ED7D2F4CA530008620D9 /* Copy and Code Sign FxPlug.framework */,
 				F2E2ED7E2F4CA530008620D9 /* Copy and Code Sign PluginManager.framework */,
 				F220BFE52F4E07EC0034AF77 /* Embed Frameworks */,
+				F20AACA52FD720500032F7FF /* CopyFiles */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				F20AACA42FD720480032F7FF /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				F2E2ED902F4CA530008620D9 /* MagicMove */,
@@ -262,8 +333,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2650;
 				LastUpgradeCheck = 2630;
 				TargetAttributes = {
+					F20AAC992FD720220032F7FF = {
+						CreatedOnToolsVersion = 26.5;
+					};
 					F2E2ED742F4CA530008620D9 = {
 						CreatedOnToolsVersion = 26.0.1;
 					};
@@ -288,6 +363,7 @@
 			targets = (
 				F2E2ED742F4CA530008620D9 /* Wrapper Application */,
 				F2E2ED7F2F4CA530008620D9 /* XPC Service */,
+				F20AAC992FD720220032F7FF /* kk-ai-helper */,
 			);
 		};
 /* End PBXProject section */
@@ -353,6 +429,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		F20AAC962FD720220032F7FF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F2E2ED712F4CA530008620D9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -370,6 +453,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		F20AACA42FD720480032F7FF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F20AAC992FD720220032F7FF /* kk-ai-helper */;
+			targetProxy = F20AACA32FD720480032F7FF /* PBXContainerItemProxy */;
+		};
 		F2E2ED832F4CA530008620D9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = F2E2ED7F2F4CA530008620D9 /* XPC Service */;
@@ -383,6 +471,37 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		F20AAC9E2FD720220032F7FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F20AAC9F2FD720220032F7FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		F2E2EDB72F4CA530008620D9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -455,6 +574,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = MagicMove;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "MagicMove/Wrapper Application/Wrapper Application-Bridging-Header.h";
 			};
 			name = Debug;
@@ -464,14 +584,23 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = keyframeless;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
-				CODE_SIGN_ENTITLEMENTS = "MagicMove/Wrapper Application/SandboxEntitlements.entitlements";
+				CODE_SIGN_ENTITLEMENTS = "Wrapper ApplicationRelease.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = 378WQ9W95U;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = NO;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				INFOPLIST_FILE = "MagicMove/Wrapper Application/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
@@ -479,6 +608,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = MagicMove;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "MagicMove/Wrapper Application/Wrapper Application-Bridging-Header.h";
 			};
 			name = Release;
@@ -619,6 +749,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		F20AACA02FD720220032F7FF /* Build configuration list for PBXNativeTarget "kk-ai-helper" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F20AAC9E2FD720220032F7FF /* Debug */,
+				F20AAC9F2FD720220032F7FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F2E2ED702F4CA530008620D9 /* Build configuration list for PBXProject "MagicMove" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -650,6 +789,10 @@
 
 /* Begin XCSwiftPackageProductDependency section */
 		AA0000000000000000000002 /* KeyframelessAI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KeyframelessAI;
+		};
+		F20AACA12FD7203B0032F7FF /* KeyframelessAI */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = KeyframelessAI;
 		};

--- a/MagicMove/MagicMove/Plugin/XPC Service-Bridging-Header.h
+++ b/MagicMove/MagicMove/Plugin/XPC Service-Bridging-Header.h
@@ -1,0 +1,5 @@
+// Bridging header for the MagicMove XPC Service target.
+// Empty: the local-LLM Swift runner imports KeyframelessAI / LocalLLMClient
+// as modules and needs nothing from ObjC here. This file only exists so the
+// (pre-existing) SWIFT_OBJC_BRIDGING_HEADER build setting resolves once Swift
+// compilation is enabled by adding the first .swift file.

--- a/MagicMove/Wrapper ApplicationRelease.entitlements
+++ b/MagicMove/Wrapper ApplicationRelease.entitlements
@@ -2,11 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.co.overpolish.keyframeless</string>
 	</array>
-	<key>com.apple.security.cs.disable-library-validation</key>
+	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>
 </plist>

--- a/MagicMove/kk-ai-helper/main.swift
+++ b/MagicMove/kk-ai-helper/main.swift
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import KeyframelessAI
+
+LocalAIHelperServer.run()

--- a/Rounded/Rounded.xcodeproj/project.pbxproj
+++ b/Rounded/Rounded.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		F23EF0142FC971CD00AFBA1E /* KeyframelessAI in Frameworks */ = {isa = PBXBuildFile; productRef = F23EF0132FC971CD00AFBA1E /* KeyframelessAI */; };
 		F26E024F2F4DE56D009D949A /* KeyframelessKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F26E024E2F4DE56D009D949A /* KeyframelessKit.framework */; };
 		F26E02502F4DE56D009D949A /* KeyframelessKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F26E024E2F4DE56D009D949A /* KeyframelessKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F2BE956E2FD766B100B5DF6A /* KeyframelessAI in Frameworks */ = {isa = PBXBuildFile; productRef = F2BE956D2FD766B100B5DF6A /* KeyframelessAI */; };
+		F2BE95722FD766CB00B5DF6A /* kk-ai-helper in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2BE95662FD7669D00B5DF6A /* kk-ai-helper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F2E2ED792F4CA530008620D9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2E2ED782F4CA530008620D9 /* Cocoa.framework */; };
 		F2E2ED812F4CA530008620D9 /* Rounded XPC Service.pluginkit in Embed PlugIns */ = {isa = PBXBuildFile; fileRef = F2E2ED802F4CA530008620D9 /* Rounded XPC Service.pluginkit */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F2E2ED852F4CA530008620D9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2E2ED842F4CA530008620D9 /* Foundation.framework */; };
@@ -24,6 +26,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		F2BE956F2FD766C200B5DF6A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F2E2ED6D2F4CA530008620D9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F2BE95652FD7669D00B5DF6A;
+			remoteInfo = "kk-ai-helper";
+		};
 		F2E2ED822F4CA530008620D9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F2E2ED6D2F4CA530008620D9 /* Project object */;
@@ -63,6 +72,25 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F2BE95642FD7669D00B5DF6A /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		F2BE95712FD766C400B5DF6A /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 6;
+			files = (
+				F2BE95722FD766CB00B5DF6A /* kk-ai-helper in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F2E2EDB92F4CA530008620D9 /* Embed PlugIns */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -79,6 +107,8 @@
 /* Begin PBXFileReference section */
 		F21396012F649EF900E1EC03 /* keyframeless.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; name = keyframeless.icon; path = ../Assets/keyframeless.icon; sourceTree = SOURCE_ROOT; };
 		F26E024E2F4DE56D009D949A /* KeyframelessKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = KeyframelessKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F2BE95662FD7669D00B5DF6A /* kk-ai-helper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "kk-ai-helper"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F2BE95732FD766E500B5DF6A /* Wrapper ApplicationRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Wrapper ApplicationRelease.entitlements"; sourceTree = "<group>"; };
 		F2E2ED752F4CA530008620D9 /* Rounded.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Rounded.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2E2ED782F4CA530008620D9 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		F2E2ED802F4CA530008620D9 /* Rounded XPC Service.pluginkit */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Rounded XPC Service.pluginkit"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -130,6 +160,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		F2BE95672FD7669D00B5DF6A /* kk-ai-helper */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "kk-ai-helper";
+			sourceTree = "<group>";
+		};
 		F2E2ED902F4CA530008620D9 /* Rounded */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -142,6 +177,14 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		F2BE95632FD7669D00B5DF6A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F2BE956E2FD766B100B5DF6A /* KeyframelessAI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F2E2ED722F4CA530008620D9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -171,8 +214,10 @@
 		F2E2ED6C2F4CA530008620D9 = {
 			isa = PBXGroup;
 			children = (
+				F2BE95732FD766E500B5DF6A /* Wrapper ApplicationRelease.entitlements */,
 				F21396012F649EF900E1EC03 /* keyframeless.icon */,
 				F2E2ED902F4CA530008620D9 /* Rounded */,
+				F2BE95672FD7669D00B5DF6A /* kk-ai-helper */,
 				F2E2ED772F4CA530008620D9 /* Frameworks */,
 				F2E2ED762F4CA530008620D9 /* Products */,
 			);
@@ -183,6 +228,7 @@
 			children = (
 				F2E2ED752F4CA530008620D9 /* Rounded.app */,
 				F2E2ED802F4CA530008620D9 /* Rounded XPC Service.pluginkit */,
+				F2BE95662FD7669D00B5DF6A /* kk-ai-helper */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -204,6 +250,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		F2BE95652FD7669D00B5DF6A /* kk-ai-helper */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F2BE956C2FD7669D00B5DF6A /* Build configuration list for PBXNativeTarget "kk-ai-helper" */;
+			buildPhases = (
+				F2BE95622FD7669D00B5DF6A /* Sources */,
+				F2BE95632FD7669D00B5DF6A /* Frameworks */,
+				F2BE95642FD7669D00B5DF6A /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F2BE95672FD7669D00B5DF6A /* kk-ai-helper */,
+			);
+			name = "kk-ai-helper";
+			packageProductDependencies = (
+				F2BE956D2FD766B100B5DF6A /* KeyframelessAI */,
+			);
+			productName = "kk-ai-helper";
+			productReference = F2BE95662FD7669D00B5DF6A /* kk-ai-helper */;
+			productType = "com.apple.product-type.tool";
+		};
 		F2E2ED742F4CA530008620D9 /* Wrapper Application */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F2E2EDBA2F4CA530008620D9 /* Build configuration list for PBXNativeTarget "Wrapper Application" */;
@@ -240,10 +309,12 @@
 				F2E2ED7D2F4CA530008620D9 /* Copy and Code Sign FxPlug.framework */,
 				F2E2ED7E2F4CA530008620D9 /* Copy and Code Sign PluginManager.framework */,
 				F220BFE52F4E07EC0034AF77 /* Embed Frameworks */,
+				F2BE95712FD766C400B5DF6A /* CopyFiles */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				F2BE95702FD766C200B5DF6A /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				F2E2ED902F4CA530008620D9 /* Rounded */,
@@ -263,8 +334,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2650;
 				LastUpgradeCheck = 2640;
 				TargetAttributes = {
+					F2BE95652FD7669D00B5DF6A = {
+						CreatedOnToolsVersion = 26.5;
+					};
 					F2E2ED742F4CA530008620D9 = {
 						CreatedOnToolsVersion = 26.0.1;
 					};
@@ -295,6 +370,7 @@
 			targets = (
 				F2E2ED742F4CA530008620D9 /* Wrapper Application */,
 				F2E2ED7F2F4CA530008620D9 /* XPC Service */,
+				F2BE95652FD7669D00B5DF6A /* kk-ai-helper */,
 			);
 		};
 /* End PBXProject section */
@@ -360,6 +436,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		F2BE95622FD7669D00B5DF6A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F2E2ED712F4CA530008620D9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -377,6 +460,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		F2BE95702FD766C200B5DF6A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F2BE95652FD7669D00B5DF6A /* kk-ai-helper */;
+			targetProxy = F2BE956F2FD766C200B5DF6A /* PBXContainerItemProxy */;
+		};
 		F2E2ED832F4CA530008620D9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = F2E2ED7F2F4CA530008620D9 /* XPC Service */;
@@ -390,6 +478,37 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		F2BE956A2FD7669D00B5DF6A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F2BE956B2FD7669D00B5DF6A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		F2E2EDB72F4CA530008620D9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -419,11 +538,10 @@
 		F2E2EDB82F4CA530008620D9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = 378WQ9W95U;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -462,6 +580,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Rounded;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Rounded/Wrapper Application/Wrapper Application-Bridging-Header.h";
 			};
 			name = Debug;
@@ -471,13 +590,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = keyframeless;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
-				CODE_SIGN_ENTITLEMENTS = "Rounded/Wrapper Application/SandboxEntitlements.entitlements";
+				CODE_SIGN_ENTITLEMENTS = "Wrapper ApplicationRelease.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = 378WQ9W95U;
+				DEVELOPMENT_TEAM = 378WQ9W95U;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				INFOPLIST_FILE = "Rounded/Wrapper Application/Info.plist";
@@ -486,6 +603,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Rounded;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Rounded/Wrapper Application/Wrapper Application-Bridging-Header.h";
 			};
 			name = Release;
@@ -628,6 +746,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		F2BE956C2FD7669D00B5DF6A /* Build configuration list for PBXNativeTarget "kk-ai-helper" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F2BE956A2FD7669D00B5DF6A /* Debug */,
+				F2BE956B2FD7669D00B5DF6A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F2E2ED702F4CA530008620D9 /* Build configuration list for PBXProject "Rounded" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -659,6 +786,10 @@
 
 /* Begin XCSwiftPackageProductDependency section */
 		F23EF0132FC971CD00AFBA1E /* KeyframelessAI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KeyframelessAI;
+		};
+		F2BE956D2FD766B100B5DF6A /* KeyframelessAI */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = KeyframelessAI;
 		};

--- a/Rounded/Rounded/Plugin/OSC/OSC.m
+++ b/Rounded/Rounded/Plugin/OSC/OSC.m
@@ -13,7 +13,7 @@
 // Mirrors KKOSCGuideBridge's position-notification name (the bridge posts it);
 // the plugin returns this as its help-guide refresh notification.
 NSNotificationName const kRoundedOSCPositionNotification =
-    @"com.overpolish.kk.oscGuidePosition";
+    @"co.overpolish.kk.oscGuidePosition";
 
 static RoundedOSC *sCurrentOSC = nil;
 

--- a/Rounded/Wrapper ApplicationRelease.entitlements
+++ b/Rounded/Wrapper ApplicationRelease.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.co.overpolish.keyframeless</string>
+	</array>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/Rounded/kk-ai-helper/main.swift
+++ b/Rounded/kk-ai-helper/main.swift
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 overpolish
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+import KeyframelessAI
+
+LocalAIHelperServer.run()


### PR DESCRIPTION
Local LLMs for AI functionality. Gated behind 24Gb RAM and Silicon Mac, smaller models gave poor behaviour and slow results.

Models:
- `Gemma 4 26B`
- `Qwen3 30B (A3B)`, I also considered Qwen 3.5 9B although the speed was 2x slower and results worse.

Workflow extensions have a 1Gb watermark limit, which means models CAN'T be loaded into memory, as a workaround we spin the model and processing out-of-process. Plugins do not have this limitation, however, I've opted to use the same approach throughout to avoid memory exhaustion from different plugins loading models. The other benefit of this approach is that models loaded by other plugins/workflow extensions stay warm—load model in one place, use it in another without the cold start.

**Arch**

```mermaid
flowchart TB
    subgraph plugin ["FxPlug plugin (XPC Service)"]
        PA["AI: AIPluginAgent"]
    end

    subgraph ext ["Workflow extension, e.g. Steno (.appex)"]
        TR["Transcription<br/>WhisperKit / Parakeet (CoreML)<br/>in-process, separate from the LLM"]
        AX["AI: AIRouter / AITransform"]
    end

    subgraph group ["App Group: group.co.overpolish.keyframeless"]
        SOCK(["kkai.sock"])
        CACHE[("HF model cache")]
    end

    HELPER["kk-ai-helper<br/>shared LLM process (MLX)<br/>first client spawns it"]
    MODEL[("LLM weights<br/>loaded once")]

    PA -->|JSON over UDS| SOCK
    AX -->|JSON over UDS| SOCK
    HELPER -.->|binds + listens| SOCK
    HELPER --> MODEL
    HELPER -->|reads| CACHE
```

## Demo `2x`
https://github.com/user-attachments/assets/61ecf433-bfba-41ef-b0eb-dfe7bdd92028

