### PR TITLE
fix: support FCP11 by reverting motion templates

### DIFF
--- a/MotionTemplates/Canvas/Effects.localized/Keyframeless/Canvas • KF/Canvas • KF.moef
+++ b/MotionTemplates/Canvas/Effects.localized/Keyframeless/Canvas • KF/Canvas • KF.moef
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE ozxmlscene>
-<ozml version="5.15">
+<ozml version="5.14">
 
-<displayversion>6.3</displayversion>
+<displayversion>6.2</displayversion>
 
 <factory id="1" uuid="46c844a813d311d8a438000a95af9f7e">
 	<description>Channel</description>

--- a/MotionTemplates/Glow/Effects.localized/Keyframeless/Glow • KF/Glow • KF.moef
+++ b/MotionTemplates/Glow/Effects.localized/Keyframeless/Glow • KF/Glow • KF.moef
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE ozxmlscene>
-<ozml version="5.15">
+<ozml version="5.14">
 
-<displayversion>6.3</displayversion>
+<displayversion>6.2</displayversion>
 
 <factory id="1" uuid="46c844a813d311d8a438000a95af9f7e">
 	<description>Channel</description>

--- a/MotionTemplates/Magic Move/Effects.localized/Keyframeless/Magic Move • KF/Magic Move • KF.moef
+++ b/MotionTemplates/Magic Move/Effects.localized/Keyframeless/Magic Move • KF/Magic Move • KF.moef
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE ozxmlscene>
-<ozml version="5.15">
+<ozml version="5.14">
 
-<displayversion>6.3</displayversion>
+<displayversion>6.2</displayversion>
 
 <factory id="1" uuid="46c844a813d311d8a438000a95af9f7e">
 	<description>Channel</description>

--- a/MotionTemplates/Rounded/Effects.localized/Keyframeless/Rounded • KF/Rounded • KF.moef
+++ b/MotionTemplates/Rounded/Effects.localized/Keyframeless/Rounded • KF/Rounded • KF.moef
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE ozxmlscene>
-<ozml version="5.15">
+<ozml version="5.14">
 
-<displayversion>6.3</displayversion>
+<displayversion>6.2</displayversion>
 
 <factory id="1" uuid="46c844a813d311d8a438000a95af9f7e">
 	<description>Channel</description>

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 	<img alt="Release" src="https://img.shields.io/github/v/release/overpolish/keyframeless?color=ff5000" />
     <img alt="License PolyForm Noncommercial 1.0.0" src="https://img.shields.io/badge/license-PolyForm_Noncommercial_1.0.0-ff5000" />
     <img alt="macOS 15+" src="https://img.shields.io/badge/15%2B-macOS?logo=apple&label=macOS&labelColor=5C5C5C&color=ff5000">
-    <img alt="Final Cut Pro 12.3+" src="https://img.shields.io/badge/12.3%2B-Final_Cut_Pro?label=Final%20Cut%20Pro&labelColor=5C5C5C&color=ff5000">
-    <img alt="Motion 6.3+" src="https://img.shields.io/badge/6.3%2B-Motion?label=Motion&labelColor=5C5C5C&color=ff5000">
+    <img alt="Final Cut Pro 11+" src="https://img.shields.io/badge/11%2B-Final_Cut_Pro?label=Final%20Cut%20Pro&labelColor=5C5C5C&color=ff5000">
     <img alt="Architectures - Silicon and Intel" src="https://img.shields.io/badge/Silicon_%7C_Intel-architectures?logo=apple&label=Compatible%20with&labelColor=5C5C5C&color=ff5000">
 </div>
 

--- a/docs/canvas/index.html
+++ b/docs/canvas/index.html
@@ -41,10 +41,6 @@
           <h2>2.0.0</h2>
           <span class="date">2026-07-07</span>
         </div>
-        <div class="callout warning">
-          <div class="callout-title">Warning</div>
-          <div class="callout-body">Requires Final Cut Pro 12.3 and Motion 6.3 or later. Earlier versions are not supported.</div>
-        </div>
         <div class="group">
           <span class="tag feature">New</span>
           <ul class="bullets">

--- a/docs/changelog/canvas/2.0.0.md
+++ b/docs/changelog/canvas/2.0.0.md
@@ -1,8 +1,5 @@
 <!-- date: 2026-07-07 -->
 
-> [!WARNING]
-> Requires Final Cut Pro 12.3 and Motion 6.3 or later. Earlier versions are not supported.
-
 ### New
 
 - Rebuilt on the new Keyframeless timing engine - animate any property with keyposes across Basic and Advanced views, with no keyframes to manage

--- a/docs/changelog/glow/3.0.0.md
+++ b/docs/changelog/glow/3.0.0.md
@@ -1,8 +1,5 @@
 <!-- date: 2026-07-07 -->
 
-> [!WARNING]
-> Requires Final Cut Pro 12.3 and Motion 6.3 or later. Earlier versions are not supported.
-
 ### New
 
 - Moved to the new Keyframeless timing engine - animate radius, position, and color with keyposes

--- a/docs/changelog/magicmove/3.0.0.md
+++ b/docs/changelog/magicmove/3.0.0.md
@@ -1,8 +1,5 @@
 <!-- date: 2026-07-07 -->
 
-> [!WARNING]
-> Requires Final Cut Pro 12.3 and Motion 6.3 or later. Earlier versions are not supported.
-
 ### New
 
 - Moved to the new Keyframeless timing engine - animate position, scale, rotation, anchor, and opacity with keyposes

--- a/docs/changelog/rounded/4.0.0.md
+++ b/docs/changelog/rounded/4.0.0.md
@@ -1,8 +1,5 @@
 <!-- date: 2026-07-07 -->
 
-> [!WARNING]
-> Requires Final Cut Pro 12.3 and Motion 6.3 or later. Earlier versions are not supported.
-
 ### New
 
 - Moved to the new Keyframeless timing engine - a new interface for adding animatable properties, with Basic and Advanced tabs

--- a/docs/glow/index.html
+++ b/docs/glow/index.html
@@ -40,10 +40,6 @@
           <h2>3.0.0</h2>
           <span class="date">2026-07-07</span>
         </div>
-        <div class="callout warning">
-          <div class="callout-title">Warning</div>
-          <div class="callout-body">Requires Final Cut Pro 12.3 and Motion 6.3 or later. Earlier versions are not supported.</div>
-        </div>
         <div class="group">
           <span class="tag feature">New</span>
           <ul class="bullets">

--- a/docs/magicmove/index.html
+++ b/docs/magicmove/index.html
@@ -40,10 +40,6 @@
           <h2>3.0.0</h2>
           <span class="date">2026-07-07</span>
         </div>
-        <div class="callout warning">
-          <div class="callout-title">Warning</div>
-          <div class="callout-body">Requires Final Cut Pro 12.3 and Motion 6.3 or later. Earlier versions are not supported.</div>
-        </div>
         <div class="group">
           <span class="tag feature">New</span>
           <ul class="bullets">

--- a/docs/rounded/index.html
+++ b/docs/rounded/index.html
@@ -40,10 +40,6 @@
           <h2>4.0.0</h2>
           <span class="date">2026-07-07</span>
         </div>
-        <div class="callout warning">
-          <div class="callout-title">Warning</div>
-          <div class="callout-body">Requires Final Cut Pro 12.3 and Motion 6.3 or later. Earlier versions are not supported.</div>
-        </div>
         <div class="group">
           <span class="tag feature">New</span>
           <ul class="bullets">


### PR DESCRIPTION
Confirmed working by kaplowe (FCP 11.1) for Rounded plugin.